### PR TITLE
chore: add CI test workflow and expand Jest coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,4 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
       - run: npm ci
-      - run: npm test -- --ci
+      - run: npm test -- --ci --coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm test -- --ci

--- a/__tests__/components/calendar.test.tsx
+++ b/__tests__/components/calendar.test.tsx
@@ -11,13 +11,9 @@ jest.mock("../../components/calendar/day-component", () => {
   };
 });
 
-jest.mock("@react-navigation/native", () => {
-  const actual = jest.requireActual("@react-navigation/native");
-  return {
-    ...actual,
-    useNavigation: () => ({ navigate: jest.fn() }),
-  };
-});
+jest.mock("@react-navigation/native", () =>
+  require("../mocks/navigation").mockNavigationModule()
+);
 
 jest.mock("../../hooks/useIAP", () => ({
   useIAP: () => ({

--- a/__tests__/components/day-tasks/goals.test.tsx
+++ b/__tests__/components/day-tasks/goals.test.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import { Alert } from "react-native";
+import { fireEvent, screen, waitFor } from "@testing-library/react-native";
+import { Goals } from "../../../components/day-tasks/goals/goals";
+import { renderWithProviders } from "../../utils/render";
+import { loggedInPreloadedState } from "../../utils/day-task-helpers";
+import {
+  mockSaveTaskByCategoryMutation,
+  mockRemoveTaskMutation,
+  saveTaskByCategoryTrigger,
+  removeTaskTrigger,
+  resetApiHookMocks,
+} from "../../mocks/api-hooks";
+import { TASK_CATEGORY } from "../../../constants/constants";
+import type { GoalsData } from "../../../types/types";
+
+jest.mock("../../../services/api", () => ({
+  ...jest.requireActual("../../../services/api"),
+  useSaveTaskByCategoryMutation: () => mockSaveTaskByCategoryMutation(),
+  useRemoveTaskMutation: () => mockRemoveTaskMutation(),
+}));
+
+jest.mock("../../../hooks/useUnsavedChangesBlocker", () => ({
+  useUnsavedChangesBlocker: jest.fn(),
+}));
+
+const CONTEXT = "globalGoal";
+const TEXTAREA_PLACEHOLDER = "Напишить щось тут";
+
+describe("Goals", () => {
+  let alertSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    resetApiHookMocks();
+    alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
+  });
+
+  describe("empty state", () => {
+    it("opens the form when there is no saved goal", () => {
+      renderWithProviders(<Goals context={CONTEXT} data={null} />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      expect(screen.getByPlaceholderText(TEXTAREA_PLACEHOLDER)).toBeTruthy();
+    });
+
+    it("blocks submit and alerts when text is empty", () => {
+      renderWithProviders(<Goals context={CONTEXT} data={null} />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      fireEvent.press(screen.getByLabelText("Save goals"));
+      expect(alertSpy).toHaveBeenCalledWith(
+        "Помилка",
+        "Текстове поле не може бути порожнім"
+      );
+      expect(saveTaskByCategoryTrigger).not.toHaveBeenCalled();
+    });
+
+    it("saves the goal and exits edit mode", async () => {
+      renderWithProviders(<Goals context={CONTEXT} data={null} />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      fireEvent.changeText(
+        screen.getByPlaceholderText(TEXTAREA_PLACEHOLDER),
+        "Run a marathon"
+      );
+      fireEvent.press(screen.getByLabelText("Save goals"));
+
+      await waitFor(() => {
+        expect(saveTaskByCategoryTrigger).toHaveBeenCalledWith(
+          expect.objectContaining({
+            category: TASK_CATEGORY.GOALS,
+            context: CONTEXT,
+            year: "2025",
+            data: expect.objectContaining({ text: "Run a marathon" }),
+          })
+        );
+      });
+      expect(screen.getByText("Run a marathon")).toBeTruthy();
+    });
+  });
+
+  describe("saved state", () => {
+    const savedData: GoalsData = {
+      globalGoal: { id: "goal-1", text: "My global goal" },
+    };
+
+    it("shows saved goal text and action buttons", () => {
+      renderWithProviders(<Goals context={CONTEXT} data={savedData} />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      expect(screen.getByText("My global goal")).toBeTruthy();
+      expect(screen.getByText("Редагувати")).toBeTruthy();
+    });
+
+    it("switches to edit mode when edit is pressed", () => {
+      renderWithProviders(<Goals context={CONTEXT} data={savedData} />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      fireEvent.press(screen.getByText("Редагувати"));
+      expect(screen.getByPlaceholderText(TEXTAREA_PLACEHOLDER)).toBeTruthy();
+    });
+
+    it("removes the goal after delete confirmation", async () => {
+      alertSpy.mockImplementation(
+        (_title?: string, _msg?: string, buttons?: { onPress?: () => void }[]) => {
+          buttons?.[1]?.onPress?.();
+        }
+      );
+
+      renderWithProviders(<Goals context={CONTEXT} data={savedData} />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      fireEvent.press(screen.getByText("Видалити"));
+
+      await waitFor(() => {
+        expect(removeTaskTrigger).toHaveBeenCalledWith({
+          category: TASK_CATEGORY.GOALS,
+          context: CONTEXT,
+          year: "2025",
+        });
+      });
+    });
+  });
+});

--- a/__tests__/components/day-tasks/month-photo.test.tsx
+++ b/__tests__/components/day-tasks/month-photo.test.tsx
@@ -1,0 +1,162 @@
+import React from "react";
+import { Alert } from "react-native";
+import { fireEvent, screen, waitFor } from "@testing-library/react-native";
+import { MonthPhoto } from "../../../components/day-tasks/month-photo/month-photo";
+import { renderWithProviders } from "../../utils/render";
+import {
+  loggedInPreloadedState,
+  mockImage,
+  resetImageMock,
+  testImage,
+} from "../../utils/day-task-helpers";
+import {
+  mockSaveTaskByCategoryMutation,
+  mockRemoveTaskMutation,
+  mockDeleteImageMutation,
+  saveTaskByCategoryTrigger,
+  removeTaskTrigger,
+  resetApiHookMocks,
+} from "../../mocks/api-hooks";
+import { TASK_CATEGORY } from "../../../constants/constants";
+import type { MonthPhotoData } from "../../../types/types";
+
+jest.mock("../../../services/api", () => ({
+  ...jest.requireActual("../../../services/api"),
+  useSaveTaskByCategoryMutation: () => mockSaveTaskByCategoryMutation(),
+  useRemoveTaskMutation: () => mockRemoveTaskMutation(),
+  useDeleteImageMutation: () => mockDeleteImageMutation(),
+  useSaveImageMutation: () => [
+    jest.fn(() => ({ unwrap: () => Promise.resolve(null) })),
+    { isLoading: false },
+  ],
+  useLazyGetImageUrlQuery: () => [
+    jest.fn(() => ({
+      unwrap: () => Promise.resolve("https://example.com/image.jpg"),
+    })),
+    { isLoading: false },
+  ],
+}));
+
+jest.mock("../../../hooks/useUnsavedChangesBlocker", () => ({
+  useUnsavedChangesBlocker: jest.fn(),
+}));
+
+jest.mock("../../../hooks/useImage", () => ({
+  useImage: () => require("../../utils/day-task-helpers").mockUseImage(),
+}));
+
+const CONTEXT = "january";
+const TEXTAREA_PLACEHOLDER = "Напишить щось тут";
+
+describe("MonthPhoto", () => {
+  let alertSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    resetApiHookMocks();
+    resetImageMock();
+    alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
+  });
+
+  describe("empty state", () => {
+    it("opens the form when there is no saved photo", () => {
+      renderWithProviders(<MonthPhoto context={CONTEXT} data={null} />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      expect(screen.getByPlaceholderText(TEXTAREA_PLACEHOLDER)).toBeTruthy();
+      expect(screen.getByText("Готово")).toBeTruthy();
+    });
+
+    it("blocks submit and alerts when no image is selected", () => {
+      renderWithProviders(<MonthPhoto context={CONTEXT} data={null} />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      fireEvent.press(screen.getByText("Готово"));
+      expect(alertSpy).toHaveBeenCalledWith(
+        "Помилка",
+        "Будь ласка, оберіть зображення"
+      );
+      expect(saveTaskByCategoryTrigger).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("saved state", () => {
+    const savedData: MonthPhotoData = {
+      [CONTEXT]: {
+        id: "photo-1",
+        text: "Saved photo caption",
+        image: testImage,
+      },
+    };
+
+    beforeEach(() => {
+      mockImage = testImage;
+    });
+
+    it("shows saved caption and action buttons", () => {
+      renderWithProviders(<MonthPhoto context={CONTEXT} data={savedData} />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      expect(screen.getByText("Saved photo caption")).toBeTruthy();
+      expect(screen.getByText("Редагувати")).toBeTruthy();
+    });
+
+    it("switches to edit mode when edit is pressed", () => {
+      renderWithProviders(<MonthPhoto context={CONTEXT} data={savedData} />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      fireEvent.press(screen.getByText("Редагувати"));
+      expect(screen.getByPlaceholderText(TEXTAREA_PLACEHOLDER)).toBeTruthy();
+    });
+
+    it("saves an updated caption when editing", async () => {
+      renderWithProviders(<MonthPhoto context={CONTEXT} data={savedData} />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      fireEvent.press(screen.getByText("Редагувати"));
+      fireEvent.changeText(
+        screen.getByPlaceholderText(TEXTAREA_PLACEHOLDER),
+        "Updated caption"
+      );
+      fireEvent.press(screen.getByText("Готово"));
+
+      await waitFor(() => {
+        expect(saveTaskByCategoryTrigger).toHaveBeenCalledWith(
+          expect.objectContaining({
+            category: TASK_CATEGORY.MONTH_PHOTO,
+            context: CONTEXT,
+            year: "2025",
+            data: expect.objectContaining({
+              text: "Updated caption",
+              image: testImage,
+            }),
+          })
+        );
+      });
+    });
+
+    it("removes the photo after delete confirmation", async () => {
+      alertSpy.mockImplementation(
+        (_title?: string, _msg?: string, buttons?: { onPress?: () => void }[]) => {
+          buttons?.[1]?.onPress?.();
+        }
+      );
+
+      renderWithProviders(<MonthPhoto context={CONTEXT} data={savedData} />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      fireEvent.press(screen.getByText("Видалити"));
+
+      await waitFor(() => {
+        expect(removeTaskTrigger).toHaveBeenCalledWith({
+          category: TASK_CATEGORY.MONTH_PHOTO,
+          context: CONTEXT,
+          year: "2025",
+        });
+      });
+    });
+  });
+});

--- a/__tests__/components/day-tasks/mood-task.test.tsx
+++ b/__tests__/components/day-tasks/mood-task.test.tsx
@@ -1,0 +1,168 @@
+import React from "react";
+import { Alert } from "react-native";
+import { fireEvent, screen, waitFor } from "@testing-library/react-native";
+import { MoodTask } from "../../../components/day-tasks/mood/mood-task";
+import { renderWithProviders } from "../../utils/render";
+import { loggedInPreloadedState } from "../../utils/day-task-helpers";
+import {
+  mockSaveMoodTaskMutation,
+  mockRemoveTaskMutation,
+  mockDeleteImageMutation,
+  saveMoodTaskTrigger,
+  removeTaskTrigger,
+  resetApiHookMocks,
+} from "../../mocks/api-hooks";
+import { TASK_CATEGORY, TaskOutputType } from "../../../constants/constants";
+import type { MoodTaskData } from "../../../types/types";
+
+jest.mock("../../../services/api", () => ({
+  ...jest.requireActual("../../../services/api"),
+  useSaveMoodTaskMutation: () => mockSaveMoodTaskMutation(),
+  useRemoveTaskMutation: () => mockRemoveTaskMutation(),
+  useDeleteImageMutation: () => mockDeleteImageMutation(),
+  useSaveImageMutation: () => [
+    jest.fn(() => ({ unwrap: () => Promise.resolve(null) })),
+    { isLoading: false },
+  ],
+  useLazyGetImageUrlQuery: () => [
+    jest.fn(() => ({
+      unwrap: () => Promise.resolve("https://example.com/image.jpg"),
+    })),
+    { isLoading: false },
+  ],
+}));
+
+jest.mock("../../../hooks/useUnsavedChangesBlocker", () => ({
+  useUnsavedChangesBlocker: jest.fn(),
+}));
+
+jest.mock("../../../hooks/useImage", () => ({
+  useImage: () => require("../../utils/day-task-helpers").mockUseImage(),
+}));
+
+const DAY = "01";
+const TEXTAREA_PLACEHOLDER = "Напишить щось тут";
+
+describe("MoodTask", () => {
+  let alertSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    resetApiHookMocks();
+    require("../../utils/day-task-helpers").resetImageMock();
+    alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
+  });
+
+  describe("empty state", () => {
+    it("opens the form when there is no mood data for the day", () => {
+      renderWithProviders(
+        <MoodTask data={null} day={DAY} taskOutputType={TaskOutputType.Text} />,
+        { preloadedState: loggedInPreloadedState }
+      );
+      expect(screen.getByPlaceholderText(TEXTAREA_PLACEHOLDER)).toBeTruthy();
+    });
+
+    it("blocks submit and alerts when text is empty", () => {
+      renderWithProviders(
+        <MoodTask data={null} day={DAY} taskOutputType={TaskOutputType.Text} />,
+        { preloadedState: loggedInPreloadedState }
+      );
+      fireEvent.press(screen.getByText("Готово"));
+      expect(alertSpy).toHaveBeenCalledWith(
+        "Помилка",
+        "Текстове поле не може бути порожнім"
+      );
+      expect(saveMoodTaskTrigger).not.toHaveBeenCalled();
+    });
+
+    it("saves mood text and exits edit mode", async () => {
+      renderWithProviders(
+        <MoodTask data={null} day={DAY} taskOutputType={TaskOutputType.Text} />,
+        { preloadedState: loggedInPreloadedState }
+      );
+      fireEvent.changeText(
+        screen.getByPlaceholderText(TEXTAREA_PLACEHOLDER),
+        "Feeling calm"
+      );
+      fireEvent.press(screen.getByText("Готово"));
+
+      await waitFor(() => {
+        expect(saveMoodTaskTrigger).toHaveBeenCalledWith(
+          expect.objectContaining({
+            category: TASK_CATEGORY.MOOD,
+            day: DAY,
+            year: "2025",
+            data: expect.objectContaining({ text: "Feeling calm" }),
+          })
+        );
+      });
+      expect(screen.getByText("Feeling calm")).toBeTruthy();
+    });
+  });
+
+  describe("saved state", () => {
+    const savedData: MoodTaskData = {
+      [DAY]: {
+        id: "mood-1",
+        text: "Saved mood note",
+        image: null,
+      },
+    };
+
+    it("shows saved mood text and action buttons", () => {
+      renderWithProviders(
+        <MoodTask
+          data={savedData}
+          day={DAY}
+          taskOutputType={TaskOutputType.Text}
+        />,
+        { preloadedState: loggedInPreloadedState }
+      );
+      expect(screen.getByText("Saved mood note")).toBeTruthy();
+      expect(screen.getByText("Редагувати")).toBeTruthy();
+    });
+
+    it("switches to edit mode when edit is pressed", () => {
+      renderWithProviders(
+        <MoodTask
+          data={savedData}
+          day={DAY}
+          taskOutputType={TaskOutputType.Text}
+        />,
+        { preloadedState: loggedInPreloadedState }
+      );
+      fireEvent.press(screen.getByText("Редагувати"));
+      expect(screen.getByPlaceholderText(TEXTAREA_PLACEHOLDER)).toBeTruthy();
+    });
+
+    it("removes the mood task after delete confirmation", async () => {
+      alertSpy.mockImplementation(
+        (_title?: string, _msg?: string, buttons?: { onPress?: () => void }[]) => {
+          buttons?.[1]?.onPress?.();
+        }
+      );
+
+      renderWithProviders(
+        <MoodTask
+          data={savedData}
+          day={DAY}
+          taskOutputType={TaskOutputType.Text}
+        />,
+        { preloadedState: loggedInPreloadedState }
+      );
+      fireEvent.press(screen.getByText("Видалити"));
+
+      await waitFor(() => {
+        expect(removeTaskTrigger).toHaveBeenCalledWith({
+          category: TASK_CATEGORY.MOOD,
+          context: "",
+          day: DAY,
+          year: "2025",
+        });
+      });
+    });
+  });
+});

--- a/__tests__/components/day-tasks/plans.test.tsx
+++ b/__tests__/components/day-tasks/plans.test.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { Alert } from "react-native";
+import { fireEvent, screen, waitFor } from "@testing-library/react-native";
+import { Plans } from "../../../components/day-tasks/plans/plans";
+import { renderWithProviders } from "../../utils/render";
+import { loggedInPreloadedState } from "../../utils/day-task-helpers";
+import {
+  mockSaveTaskByCategoryMutation,
+  saveTaskByCategoryTrigger,
+  resetApiHookMocks,
+} from "../../mocks/api-hooks";
+import { MAX_PLANS_AMOUNT, TASK_CATEGORY } from "../../../constants/constants";
+import type { PlanContextData } from "../../../types/types";
+
+jest.mock("../../../services/api", () => ({
+  ...jest.requireActual("../../../services/api"),
+  useSaveTaskByCategoryMutation: () => mockSaveTaskByCategoryMutation(),
+}));
+
+const CONTEXT = "health";
+const MODAL_PLACEHOLDER = "Напишить щось тут";
+
+const makePlan = (id: string, text: string) => ({ id, text, isDone: false });
+
+describe("Plans", () => {
+  let alertSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    resetApiHookMocks();
+    alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
+  });
+
+  it("renders the add-plan button", () => {
+    renderWithProviders(<Plans context={CONTEXT} data={null} />, {
+      preloadedState: loggedInPreloadedState,
+    });
+    expect(screen.getByText("Додати пункт плану")).toBeTruthy();
+  });
+
+  it("shows existing plans in the list", () => {
+    const data: PlanContextData = {
+      [CONTEXT]: [
+        makePlan("p1", "Morning run"),
+        makePlan("p2", "Read 30 minutes"),
+      ],
+    };
+    renderWithProviders(<Plans context={CONTEXT} data={data} />, {
+      preloadedState: loggedInPreloadedState,
+    });
+    expect(screen.getByText("Morning run")).toBeTruthy();
+    expect(screen.getByText("Read 30 minutes")).toBeTruthy();
+  });
+
+  it("opens the modal and saves a new plan", async () => {
+    renderWithProviders(<Plans context={CONTEXT} data={null} />, {
+      preloadedState: loggedInPreloadedState,
+    });
+
+    fireEvent.press(screen.getByText("Додати пункт плану"));
+    expect(screen.getByText("Додайте один пункт плану")).toBeTruthy();
+
+    fireEvent.changeText(
+      screen.getByPlaceholderText(MODAL_PLACEHOLDER),
+      "New plan item"
+    );
+    fireEvent.press(screen.getByText("Додати"));
+
+    await waitFor(() => {
+      expect(saveTaskByCategoryTrigger).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: TASK_CATEGORY.PLANS,
+          context: CONTEXT,
+          year: "2025",
+          data: expect.arrayContaining([
+            expect.objectContaining({ text: "New plan item", isDone: false }),
+          ]),
+        })
+      );
+    });
+  });
+
+  it("blocks adding a plan when the maximum is reached", () => {
+    const maxPlans = Array.from({ length: MAX_PLANS_AMOUNT }, (_, i) =>
+      makePlan(`p${i}`, `Plan ${i}`)
+    );
+    const data: PlanContextData = { [CONTEXT]: maxPlans };
+
+    renderWithProviders(<Plans context={CONTEXT} data={data} />, {
+      preloadedState: loggedInPreloadedState,
+    });
+
+    fireEvent.press(screen.getByText("Додати пункт плану"));
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      "Ви не можете додати більше ніж 10 пунктів"
+    );
+    expect(screen.queryByText("Додайте один пункт плану")).toBeNull();
+  });
+});

--- a/__tests__/components/day-tasks/summary.test.tsx
+++ b/__tests__/components/day-tasks/summary.test.tsx
@@ -1,0 +1,152 @@
+import React from "react";
+import { Alert } from "react-native";
+import { fireEvent, screen, waitFor } from "@testing-library/react-native";
+import { Summary } from "../../../components/day-tasks/summary/summary";
+import { renderWithProviders } from "../../utils/render";
+import { loggedInPreloadedState } from "../../utils/day-task-helpers";
+import {
+  mockSaveTaskByCategoryMutation,
+  mockRemoveTaskMutation,
+  saveTaskByCategoryTrigger,
+  removeTaskTrigger,
+  resetApiHookMocks,
+} from "../../mocks/api-hooks";
+import { TASK_CATEGORY } from "../../../constants/constants";
+import type { SummaryContextData } from "../../../types/types";
+
+jest.mock("../../../services/api", () => ({
+  ...jest.requireActual("../../../services/api"),
+  useSaveTaskByCategoryMutation: () => mockSaveTaskByCategoryMutation(),
+  useRemoveTaskMutation: () => mockRemoveTaskMutation(),
+}));
+
+jest.mock("../../../hooks/useUnsavedChangesBlocker", () => ({
+  useUnsavedChangesBlocker: jest.fn(),
+}));
+
+const CONTEXT = "health";
+const TEXTAREA_PLACEHOLDER = "Напишить щось тут";
+
+describe("Summary", () => {
+  let alertSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    resetApiHookMocks();
+    alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
+  });
+
+  describe("empty state", () => {
+    it("opens the form when there is no saved data", () => {
+      renderWithProviders(<Summary context={CONTEXT} data={null} />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      expect(screen.getByPlaceholderText(TEXTAREA_PLACEHOLDER)).toBeTruthy();
+      expect(screen.getByText("Готово")).toBeTruthy();
+    });
+
+    it("blocks submit and alerts when text is empty", () => {
+      renderWithProviders(<Summary context={CONTEXT} data={null} />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      fireEvent.press(screen.getByText("Готово"));
+      expect(alertSpy).toHaveBeenCalledWith(
+        "Помилка",
+        "Текстове поле не може бути порожнім"
+      );
+      expect(saveTaskByCategoryTrigger).not.toHaveBeenCalled();
+    });
+
+    it("saves the summary and exits edit mode", async () => {
+      renderWithProviders(<Summary context={CONTEXT} data={null} />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      fireEvent.changeText(
+        screen.getByPlaceholderText(TEXTAREA_PLACEHOLDER),
+        "Feeling great today"
+      );
+      fireEvent.press(screen.getByText("Готово"));
+
+      await waitFor(() => {
+        expect(saveTaskByCategoryTrigger).toHaveBeenCalledWith(
+          expect.objectContaining({
+            category: TASK_CATEGORY.SUMMARY,
+            context: CONTEXT,
+            year: "2025",
+            data: expect.objectContaining({
+              text: "Feeling great today",
+              rate: 50,
+            }),
+          })
+        );
+      });
+      expect(screen.queryByPlaceholderText(TEXTAREA_PLACEHOLDER)).toBeNull();
+      expect(screen.getByText("Feeling great today")).toBeTruthy();
+    });
+  });
+
+  describe("saved state", () => {
+    const savedData: SummaryContextData = {
+      [CONTEXT]: {
+        id: "summary-1",
+        text: "Saved summary text",
+        rate: 75,
+      },
+    };
+
+    it("shows saved text and action buttons", () => {
+      renderWithProviders(<Summary context={CONTEXT} data={savedData} />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      expect(screen.getByText("Saved summary text")).toBeTruthy();
+      expect(screen.getByText("Редагувати")).toBeTruthy();
+      expect(screen.getByText("Видалити")).toBeTruthy();
+    });
+
+    it("switches to edit mode when edit is pressed", () => {
+      renderWithProviders(<Summary context={CONTEXT} data={savedData} />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      fireEvent.press(screen.getByText("Редагувати"));
+      expect(screen.getByPlaceholderText(TEXTAREA_PLACEHOLDER)).toBeTruthy();
+    });
+
+    it("cancels editing and restores the saved text", () => {
+      renderWithProviders(<Summary context={CONTEXT} data={savedData} />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      fireEvent.press(screen.getByText("Редагувати"));
+      fireEvent.changeText(
+        screen.getByPlaceholderText(TEXTAREA_PLACEHOLDER),
+        "Changed text"
+      );
+      fireEvent.press(screen.getByText("Відмінити"));
+      expect(screen.getByText("Saved summary text")).toBeTruthy();
+      expect(screen.queryByPlaceholderText(TEXTAREA_PLACEHOLDER)).toBeNull();
+    });
+
+    it("removes the task after delete confirmation", async () => {
+      alertSpy.mockImplementation(
+        (_title?: string, _msg?: string, buttons?: { onPress?: () => void }[]) => {
+          buttons?.[1]?.onPress?.();
+        }
+      );
+
+      renderWithProviders(<Summary context={CONTEXT} data={savedData} />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      fireEvent.press(screen.getByText("Видалити"));
+
+      await waitFor(() => {
+        expect(removeTaskTrigger).toHaveBeenCalledWith({
+          category: TASK_CATEGORY.SUMMARY,
+          context: CONTEXT,
+          year: "2025",
+        });
+      });
+    });
+  });
+});

--- a/__tests__/hooks/useAlbumScreen.test.ts
+++ b/__tests__/hooks/useAlbumScreen.test.ts
@@ -1,0 +1,119 @@
+import { act, renderHook } from "@testing-library/react-native";
+import { useAlbumScreen } from "../../screens/album-screen/hooks/useAlbumScreen";
+import { createHookWrapper } from "../utils/render";
+import { loggedInPreloadedState } from "../utils/day-task-helpers";
+import { mockGetUserDataQuery, resetApiHookMocks } from "../mocks/api-hooks";
+
+jest.mock("../../services/api", () => ({
+  ...jest.requireActual("../../services/api"),
+  useGetUserDataQuery: (...args: unknown[]) => mockGetUserDataQuery(...args),
+}));
+
+const setUserData = (data: unknown) => {
+  mockGetUserDataQuery.mockReturnValue({
+    data,
+    isLoading: false,
+    isFetching: false,
+    error: undefined,
+    refetch: jest.fn(),
+  });
+};
+
+describe("useAlbumScreen", () => {
+  beforeEach(() => {
+    resetApiHookMocks();
+  });
+
+  it("returns null photos when there is no month photo data", () => {
+    setUserData(null);
+    const { result } = renderHook(() => useAlbumScreen(), {
+      wrapper: createHookWrapper(loggedInPreloadedState),
+    });
+
+    expect(result.current.photos).toBeNull();
+    expect(result.current.currentMonth).toBe("Рік");
+  });
+
+  it("maps month photos and sets the current month label", () => {
+    setUserData({
+      monthPhoto: {
+        january: {
+          id: "p1",
+          text: "Winter",
+          image: { id: "img1", uri: "file://jan.jpg" },
+        },
+        march: {
+          id: "p2",
+          text: "Spring",
+          image: { id: "img2", uri: "file://mar.jpg" },
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useAlbumScreen(), {
+      wrapper: createHookWrapper(loggedInPreloadedState),
+    });
+
+    expect(result.current.photos).toHaveLength(2);
+    expect(result.current.photos?.[0].month).toBe("january");
+    expect(result.current.currentMonth).toBe("Січень");
+  });
+
+  it("updates the current month when snapping to another slide", () => {
+    setUserData({
+      monthPhoto: {
+        january: {
+          id: "p1",
+          text: "Winter",
+          image: { id: "img1", uri: "file://jan.jpg" },
+        },
+        march: {
+          id: "p2",
+          text: "Spring",
+          image: { id: "img2", uri: "file://mar.jpg" },
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useAlbumScreen(), {
+      wrapper: createHookWrapper(loggedInPreloadedState),
+    });
+
+    act(() => {
+      result.current.handleSnapToItem(1);
+    });
+
+    expect(result.current.currentMonth).toBe("Березень");
+  });
+
+  it("delegates carousel navigation to the carousel ref", () => {
+    setUserData({
+      monthPhoto: {
+        january: {
+          id: "p1",
+          text: "Winter",
+          image: { id: "img1", uri: "file://jan.jpg" },
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useAlbumScreen(), {
+      wrapper: createHookWrapper(loggedInPreloadedState),
+    });
+
+    const next = jest.fn();
+    const prev = jest.fn();
+    (result.current.carouselRef as { current: unknown }).current = {
+      next,
+      prev,
+    };
+
+    act(() => {
+      result.current.handleForward();
+      result.current.handleBack();
+    });
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(prev).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/hooks/usePlansScreen.test.ts
+++ b/__tests__/hooks/usePlansScreen.test.ts
@@ -1,0 +1,137 @@
+import { Alert } from "react-native";
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+import { usePlansScreen } from "../../components/plans-view/hooks/usePlansScreen";
+import { createHookWrapper } from "../utils/render";
+import { loggedInPreloadedState } from "../utils/day-task-helpers";
+import {
+  mockSaveTaskByCategoryMutation,
+  saveTaskByCategoryTrigger,
+  resetApiHookMocks,
+} from "../mocks/api-hooks";
+import { PlansViewOptions, TASK_CATEGORY } from "../../constants/constants";
+import type { PlanContextData, PlanScreenData } from "../../types/types";
+
+jest.mock("../../services/api", () => ({
+  ...jest.requireActual("../../services/api"),
+  useSaveTaskByCategoryMutation: () => mockSaveTaskByCategoryMutation(),
+  useLazyGetUserDataQuery: () => [
+    jest.fn(() => ({ unwrap: () => Promise.resolve(null) })),
+    { isLoading: false },
+  ],
+}));
+
+const plans: PlanContextData = {
+  health: [{ id: "h1", text: "Morning run", isDone: false }],
+  work: [
+    {
+      id: "w1",
+      text: "Ship feature",
+      isDone: true,
+      month: "january",
+    } as PlanScreenData,
+  ],
+};
+
+describe("usePlansScreen", () => {
+  let alertSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    resetApiHookMocks();
+    alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
+  });
+
+  it("builds contextEntries for non-empty contexts only", () => {
+    const { result } = renderHook(() => usePlansScreen({ plans }), {
+      wrapper: createHookWrapper(loggedInPreloadedState),
+    });
+
+    expect(result.current.contextEntries).toHaveLength(2);
+    expect(result.current.contextEntries.map((entry) => entry.context)).toEqual([
+      "health",
+      "work",
+    ]);
+  });
+
+  it("groups plans by month", () => {
+    const { result } = renderHook(() => usePlansScreen({ plans }), {
+      wrapper: createHookWrapper(loggedInPreloadedState),
+    });
+
+    expect(result.current.monthlyPlans.january).toHaveLength(1);
+    expect(result.current.monthlyPlans.january?.[0].text).toBe("Ship feature");
+  });
+
+  it("adds a plan through handleAddPlan", async () => {
+    const { result } = renderHook(() => usePlansScreen({ plans }), {
+      wrapper: createHookWrapper(loggedInPreloadedState),
+    });
+
+    await act(async () => {
+      await result.current.handleAddPlan("Evening stretch", "health");
+    });
+
+    expect(saveTaskByCategoryTrigger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: TASK_CATEGORY.PLANS,
+        context: "health",
+        year: "2025",
+        data: expect.arrayContaining([
+          expect.objectContaining({ text: "Evening stretch", isDone: false }),
+        ]),
+      })
+    );
+  });
+
+  it("deletes a plan after confirmation", async () => {
+    alertSpy.mockImplementation(
+      (_title?: string, _msg?: string, buttons?: { onPress?: () => void }[]) => {
+        buttons?.[1]?.onPress?.();
+      }
+    );
+
+    const { result } = renderHook(() => usePlansScreen({ plans }), {
+      wrapper: createHookWrapper(loggedInPreloadedState),
+    });
+
+    await act(async () => {
+      await result.current.handleDeletePlan("h1", "health");
+    });
+
+    await waitFor(() => {
+      expect(saveTaskByCategoryTrigger).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: TASK_CATEGORY.PLANS,
+          context: "health",
+          data: [],
+        })
+      );
+    });
+  });
+
+  it("marks a plan as complete", async () => {
+    const { result } = renderHook(() => usePlansScreen({ plans }), {
+      wrapper: createHookWrapper(loggedInPreloadedState),
+    });
+
+    await act(async () => {
+      await result.current.handleCompletePlan({
+        plan: plans.health![0] as PlanScreenData,
+        value: true,
+        context: "health",
+        view: PlansViewOptions.context,
+      });
+    });
+
+    expect(saveTaskByCategoryTrigger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: TASK_CATEGORY.PLANS,
+        context: "health",
+        data: [expect.objectContaining({ id: "h1", isDone: true })],
+      })
+    );
+  });
+});

--- a/__tests__/mocks/api-hooks.ts
+++ b/__tests__/mocks/api-hooks.ts
@@ -29,7 +29,79 @@ export const mockLazyGetUserDataQuery = jest.fn(() => [
   { isLoading: false },
 ]);
 
+export const createProfileTrigger = jest.fn(() => ({
+  unwrap: () => Promise.resolve(null),
+}));
+
 export const mockCreateProfileMutation = jest.fn(() => [
-  jest.fn(() => ({ unwrap: jest.fn(() => Promise.resolve(null)) })),
+  createProfileTrigger,
   { isLoading: false },
 ]);
+
+export const saveTaskByCategoryTrigger = jest.fn(() => ({
+  unwrap: () => Promise.resolve(null),
+}));
+
+export const mockSaveTaskByCategoryMutation = jest.fn(() => [
+  saveTaskByCategoryTrigger,
+  { isLoading: false },
+]);
+
+export const removeTaskTrigger = jest.fn(() => ({
+  unwrap: () => Promise.resolve(null),
+}));
+
+export const mockRemoveTaskMutation = jest.fn(() => [
+  removeTaskTrigger,
+  { isLoading: false },
+]);
+
+export const saveMoodTaskTrigger = jest.fn(() => ({
+  unwrap: () => Promise.resolve(null),
+}));
+
+export const mockSaveMoodTaskMutation = jest.fn(() => [
+  saveMoodTaskTrigger,
+  { isLoading: false },
+]);
+
+export const deleteImageTrigger = jest.fn(() => ({
+  unwrap: () => Promise.resolve(null),
+}));
+
+export const mockDeleteImageMutation = jest.fn(() => [
+  deleteImageTrigger,
+  { isLoading: false },
+]);
+
+export const saveImageTrigger = jest.fn(() => ({
+  unwrap: () => Promise.resolve("https://example.com/image.jpg"),
+}));
+
+export const mockSaveImageMutation = jest.fn(() => [
+  saveImageTrigger,
+  { isLoading: false },
+]);
+
+export const mockLazyGetImageUrlQuery = jest.fn(() => [
+  jest.fn(() => ({
+    unwrap: jest.fn(() => Promise.resolve("https://example.com/image.jpg")),
+  })),
+  { isLoading: false },
+]);
+
+export const resetApiHookMocks = () => {
+  createProfileTrigger.mockClear();
+  saveTaskByCategoryTrigger.mockClear();
+  removeTaskTrigger.mockClear();
+  saveMoodTaskTrigger.mockClear();
+  deleteImageTrigger.mockClear();
+  saveImageTrigger.mockClear();
+  mockCreateProfileMutation.mockClear();
+  mockSaveTaskByCategoryMutation.mockClear();
+  mockRemoveTaskMutation.mockClear();
+  mockSaveMoodTaskMutation.mockClear();
+  mockDeleteImageMutation.mockClear();
+  mockSaveImageMutation.mockClear();
+  mockGetUserDataQuery.mockClear();
+};

--- a/__tests__/mocks/auth-hooks.ts
+++ b/__tests__/mocks/auth-hooks.ts
@@ -1,18 +1,36 @@
+export const signInTrigger = jest.fn(() => ({
+  unwrap: () => Promise.resolve({ uid: "test-uid", email: "test@example.com" }),
+}));
+
+export const sendPasswordResetTrigger = jest.fn(() => ({
+  unwrap: () => Promise.resolve(null),
+}));
+
+export const createUserTrigger = jest.fn(() => ({
+  unwrap: () =>
+    Promise.resolve({ uid: "new-uid", email: "test@example.com" }),
+}));
+
 export const mockSignInUserMutation = jest.fn(() => [
-  jest.fn(() => ({ unwrap: jest.fn(() => Promise.resolve({ uid: "test-uid" })) })),
+  signInTrigger,
   { isLoading: false },
 ]);
 
 export const mockSendPasswordResetMutation = jest.fn(() => [
-  jest.fn(() => ({ unwrap: jest.fn(() => Promise.resolve(null)) })),
+  sendPasswordResetTrigger,
   { isLoading: false },
 ]);
 
 export const mockCreateUserMutation = jest.fn(() => [
-  jest.fn(() => ({
-    unwrap: jest.fn(() =>
-      Promise.resolve({ uid: "new-uid", email: "test@example.com" })
-    ),
-  })),
+  createUserTrigger,
   { isLoading: false },
 ]);
+
+export const resetAuthHookMocks = () => {
+  signInTrigger.mockClear();
+  sendPasswordResetTrigger.mockClear();
+  createUserTrigger.mockClear();
+  mockSignInUserMutation.mockClear();
+  mockSendPasswordResetMutation.mockClear();
+  mockCreateUserMutation.mockClear();
+};

--- a/__tests__/mocks/navigation.ts
+++ b/__tests__/mocks/navigation.ts
@@ -1,0 +1,24 @@
+export const mockNavigate = jest.fn();
+export const mockReplace = jest.fn();
+export const mockPush = jest.fn();
+export const mockGoBack = jest.fn();
+
+export const mockNavigationModule = () => {
+  const actual = jest.requireActual("@react-navigation/native");
+  return {
+    ...actual,
+    useNavigation: () => ({
+      navigate: mockNavigate,
+      replace: mockReplace,
+      push: mockPush,
+      goBack: mockGoBack,
+    }),
+  };
+};
+
+export const resetNavigationMocks = () => {
+  mockNavigate.mockReset();
+  mockReplace.mockReset();
+  mockPush.mockReset();
+  mockGoBack.mockReset();
+};

--- a/__tests__/screens/album-screen.test.tsx
+++ b/__tests__/screens/album-screen.test.tsx
@@ -1,0 +1,122 @@
+import React from "react";
+import { fireEvent, screen } from "@testing-library/react-native";
+import { AlbumScreen } from "../../screens/album-screen/album-screen";
+import { renderWithProviders } from "../utils/render";
+import { loggedInPreloadedState } from "../utils/day-task-helpers";
+import { mockGetUserDataQuery, resetApiHookMocks } from "../mocks/api-hooks";
+
+jest.mock("../../services/api", () => ({
+  ...jest.requireActual("../../services/api"),
+  useGetUserDataQuery: (...args: unknown[]) => mockGetUserDataQuery(...args),
+}));
+
+jest.mock("react-native-reanimated-carousel", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+  const Carousel = ({
+    data,
+    renderItem,
+  }: {
+    data: unknown[];
+    renderItem: (args: { item: unknown; index: number }) => React.ReactNode;
+  }) => (
+    <View testID="album-carousel">
+      {data.map((item, index) => (
+        <View key={index}>{renderItem({ item, index })}</View>
+      ))}
+    </View>
+  );
+  return { __esModule: true, default: Carousel };
+});
+
+const mockHandleForward = jest.fn();
+const mockHandleBack = jest.fn();
+
+jest.mock("../../screens/album-screen/hooks/useAlbumScreen", () => ({
+  useAlbumScreen: () => require("../utils/album-screen-test-state").getAlbumScreenState(),
+}));
+
+const setUserData = (data: unknown) => {
+  mockGetUserDataQuery.mockReturnValue({
+    data,
+    isLoading: false,
+    isFetching: false,
+    error: undefined,
+    refetch: jest.fn(),
+  });
+};
+
+describe("AlbumScreen", () => {
+  beforeEach(() => {
+    resetApiHookMocks();
+    const state = require("../utils/album-screen-test-state");
+    state.resetAlbumScreenState();
+    state.setAlbumScreenState({
+      handleForward: mockHandleForward,
+      handleBack: mockHandleBack,
+    });
+    mockHandleForward.mockClear();
+    mockHandleBack.mockClear();
+  });
+
+  it("shows the empty screen when there are no photos", () => {
+    setUserData(null);
+    require("../utils/album-screen-test-state").setAlbumScreenState({
+      photos: null,
+      currentMonth: "Рік",
+      carouselSize: { width: 0, height: 0 },
+      handleForward: mockHandleForward,
+      handleBack: mockHandleBack,
+    });
+
+    renderWithProviders(<AlbumScreen />, {
+      preloadedState: loggedInPreloadedState,
+    });
+    expect(screen.getByText("Поки що тут нічого немає")).toBeTruthy();
+  });
+
+  describe("with photos", () => {
+    beforeEach(() => {
+      require("../utils/album-screen-test-state").setAlbumScreenState({
+        photos: [
+          {
+            month: "january",
+            id: "p1",
+            text: "Winter memories",
+            image: { id: "img1", uri: "file://jan.jpg" },
+          },
+          {
+            month: "march",
+            id: "p2",
+            text: "Spring walk",
+            image: { id: "img2", uri: "file://mar.jpg" },
+          },
+        ],
+        currentMonth: "Січень",
+        carouselSize: { width: 300, height: 400 },
+        handleForward: mockHandleForward,
+        handleBack: mockHandleBack,
+      });
+    });
+
+    it("renders carousel items and the current month label", () => {
+      renderWithProviders(<AlbumScreen />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      expect(screen.getByTestId("album-carousel")).toBeTruthy();
+      expect(screen.getByText("Winter memories")).toBeTruthy();
+      expect(screen.getByText("Січень")).toBeTruthy();
+    });
+
+    it("calls navigation handlers when arrows are pressed", () => {
+      renderWithProviders(<AlbumScreen />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      const buttons = screen.getAllByRole("button");
+      fireEvent.press(buttons[0]);
+      fireEvent.press(buttons[buttons.length - 1]);
+      expect(mockHandleBack).toHaveBeenCalledTimes(1);
+      expect(mockHandleForward).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/__tests__/screens/dashboard-screen.test.tsx
+++ b/__tests__/screens/dashboard-screen.test.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { fireEvent, screen } from "@testing-library/react-native";
+import { DashboardScreen } from "../../screens/dashboard-screen/dashboard-screen";
+import { renderWithProviders } from "../utils/render";
+import { loggedInPreloadedState } from "../utils/day-task-helpers";
+import { mockGetUserDataQuery, resetApiHookMocks } from "../mocks/api-hooks";
+import { mockNavigate, resetNavigationMocks } from "../mocks/navigation";
+import { SCREENS } from "../../constants/constants";
+
+jest.mock("@react-navigation/native", () =>
+  require("../mocks/navigation").mockNavigationModule()
+);
+
+jest.mock("../../services/api", () => ({
+  ...jest.requireActual("../../services/api"),
+  useGetUserDataQuery: (...args: unknown[]) => mockGetUserDataQuery(...args),
+}));
+
+jest.mock("react-native-circular-progress-indicator", () => {
+  const { Text } = require("react-native");
+  return {
+    __esModule: true,
+    default: ({ value }: { value: number }) => (
+      <Text testID="circular-progress">{`${value}%`}</Text>
+    ),
+  };
+});
+
+const setUserData = (data: unknown) => {
+  mockGetUserDataQuery.mockReturnValue({
+    data,
+    isLoading: false,
+    isFetching: false,
+    error: undefined,
+    refetch: jest.fn(),
+  });
+};
+
+describe("DashboardScreen", () => {
+  beforeEach(() => {
+    resetApiHookMocks();
+    resetNavigationMocks();
+  });
+
+  it("shows the empty screen when there are no plans", () => {
+    setUserData(null);
+    renderWithProviders(<DashboardScreen />, {
+      preloadedState: loggedInPreloadedState,
+    });
+    expect(screen.getByText("Поки що тут нічого немає")).toBeTruthy();
+  });
+
+  it("shows the empty screen when all progress is zero", () => {
+    setUserData({ plans: { health: [] } });
+    renderWithProviders(<DashboardScreen />, {
+      preloadedState: loggedInPreloadedState,
+    });
+    expect(screen.getByText("Поки що тут нічого немає")).toBeTruthy();
+  });
+
+  describe("with populated plans", () => {
+    beforeEach(() => {
+      setUserData({
+        plans: {
+          health: [
+            { id: "h1", text: "Run", isDone: true },
+            { id: "h2", text: "Stretch", isDone: false },
+          ],
+          work: [{ id: "w1", text: "Ship feature", isDone: true }],
+        },
+      });
+    });
+
+    it("renders aggregate stats", () => {
+      renderWithProviders(<DashboardScreen />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      expect(screen.getByText("67%")).toBeTruthy();
+      expect(screen.getByText("Виконано")).toBeTruthy();
+    });
+
+    it("renders a section per context with data", () => {
+      renderWithProviders(<DashboardScreen />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      expect(screen.getByText("Тіло")).toBeTruthy();
+      expect(screen.getByText("Сродна праця")).toBeTruthy();
+    });
+
+    it("navigates to the plans tab when a context section is pressed", () => {
+      renderWithProviders(<DashboardScreen />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      fireEvent.press(screen.getByText("Тіло"));
+      expect(mockNavigate).toHaveBeenCalledWith(SCREENS.HOME, {
+        screen: SCREENS.PLANS,
+      });
+    });
+  });
+});

--- a/__tests__/screens/day-overview-screen.test.tsx
+++ b/__tests__/screens/day-overview-screen.test.tsx
@@ -1,0 +1,136 @@
+import React from "react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react-native";
+import DayOverviewScreen from "../../screens/day-overview-screen";
+import { renderWithProviders } from "../utils/render";
+import { TASK_CATEGORY, TaskOutputType } from "../../constants/constants";
+
+jest.mock("../../hooks/useDayTasks", () => ({
+  useDayTasks: () => require("../utils/day-overview-test-state").getDayOverviewState(),
+}));
+
+jest.mock("../../components/tasks-list", () => ({
+  TasksList: () => {
+    const { Text } = require("react-native");
+    return <Text>TasksListMock</Text>;
+  },
+}));
+
+jest.mock("../../components/modals/completed-task-modal", () => ({
+  CompletedTaskModal: () => {
+    const { Text } = require("react-native");
+    return <Text>CompletedModal</Text>;
+  },
+}));
+
+const mockSetOptions = jest.fn();
+const mockRoute = { params: { currentDay: "2025-12-01" } };
+const mockNavigation = { setOptions: mockSetOptions };
+
+describe("DayOverviewScreen", () => {
+  const state = require("../utils/day-overview-test-state");
+
+  beforeEach(() => {
+    state.resetDayOverviewState();
+    mockSetOptions.mockClear();
+  });
+
+  it("sets the navigation title from the current day", () => {
+    renderWithProviders(
+      <DayOverviewScreen route={mockRoute as never} navigation={mockNavigation as never} />
+    );
+    expect(mockSetOptions).toHaveBeenCalledWith({ title: "01.12.2025" });
+  });
+
+  it("shows an empty state when there are no day tasks", () => {
+    state.setDayOverviewState({ dayTasks: null, total: 0, error: null });
+    renderWithProviders(
+      <DayOverviewScreen route={mockRoute as never} navigation={mockNavigation as never} />
+    );
+    expect(screen.getByText("Поки що тут нічого немає")).toBeTruthy();
+  });
+
+  it("renders progress and tasks when day data exists", () => {
+    state.setDayOverviewState({
+      dayTasks: {
+        config: {
+          videoText: "Watch this",
+          videoId: "abc",
+          dayTaskConfig: {
+            category: TASK_CATEGORY.SUMMARY,
+            grade: 1,
+            context: "health",
+            taskOutputType: TaskOutputType.Text,
+            text: "Day task",
+            title: "Title",
+          },
+          moodTaskConfig: {
+            category: TASK_CATEGORY.MOOD,
+            grade: 1,
+            context: "health",
+            taskOutputType: TaskOutputType.Text,
+            text: "Mood task",
+            title: "Mood",
+          },
+        },
+      },
+      total: 42,
+      error: null,
+    });
+
+    renderWithProviders(
+      <DayOverviewScreen route={mockRoute as never} navigation={mockNavigation as never} />
+    );
+    expect(screen.getByText("42%")).toBeTruthy();
+    expect(screen.getByText("TasksListMock")).toBeTruthy();
+  });
+
+  it("shows an error state with retry", () => {
+    const mockRefresh = jest.fn();
+    state.setDayOverviewState({
+      dayTasks: null,
+      total: 0,
+      error: new Error("failed"),
+      refresh: mockRefresh,
+    });
+
+    renderWithProviders(
+      <DayOverviewScreen route={mockRoute as never} navigation={mockNavigation as never} />
+    );
+    fireEvent.press(screen.getByText("Retry"));
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the completed modal when progress reaches 100%", async () => {
+    state.setDayOverviewState({
+      dayTasks: { config: {} },
+      total: 80,
+      error: null,
+    });
+
+    const view = renderWithProviders(
+      <DayOverviewScreen route={mockRoute as never} navigation={mockNavigation as never} />
+    );
+
+    act(() => {
+      state.setDayOverviewState({
+        dayTasks: { config: {} },
+        total: 100,
+        error: null,
+      });
+    });
+
+    act(() => {
+      view.rerender(
+        <DayOverviewScreen
+          route={{ params: { currentDay: "2025-12-01" } } as never}
+          navigation={mockNavigation as never}
+        />
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("100%")).toBeTruthy();
+      expect(screen.getByText("CompletedModal")).toBeTruthy();
+    });
+  });
+});

--- a/__tests__/screens/intro-screen.test.tsx
+++ b/__tests__/screens/intro-screen.test.tsx
@@ -3,19 +3,9 @@ import { screen } from "@testing-library/react-native";
 import { IntroScreen } from "../../screens/intro-screen";
 import { renderWithProviders } from "../utils/render";
 
-const mockReplace = jest.fn();
-
-jest.mock("@react-navigation/native", () => {
-  const actual = jest.requireActual("@react-navigation/native");
-  return {
-    ...actual,
-    useNavigation: () => ({
-      navigate: jest.fn(),
-      replace: mockReplace,
-      push: jest.fn(),
-    }),
-  };
-});
+jest.mock("@react-navigation/native", () =>
+  require("../mocks/navigation").mockNavigationModule()
+);
 
 jest.mock("react-native-reanimated-carousel", () => {
   const { View } = require("react-native");

--- a/__tests__/screens/loading-screen.test.tsx
+++ b/__tests__/screens/loading-screen.test.tsx
@@ -1,24 +1,33 @@
 import React from "react";
 import { LoadingScreen } from "../../screens/loading-screen";
 import { renderWithProviders } from "../utils/render";
+import { mockNavigate, resetNavigationMocks } from "../mocks/navigation";
+import { SCREENS } from "../../constants/constants";
+import type { SerializableUser } from "../../types/user";
 
-const mockNavigate = jest.fn();
+jest.mock("@react-navigation/native", () =>
+  require("../mocks/navigation").mockNavigationModule()
+);
 
-jest.mock("@react-navigation/native", () => {
-  const actual = jest.requireActual("@react-navigation/native");
-  return {
-    ...actual,
-    useNavigation: () => ({ navigate: mockNavigate }),
-  };
-});
+const mockUseCalendarDayManager = jest.fn(() => ({ isLoading: false }));
 
 jest.mock("../../hooks/useCalendarDayManager", () => ({
-  useCalendarDayManager: () => ({ isLoading: false }),
+  useCalendarDayManager: () => mockUseCalendarDayManager(),
 }));
+
+const testUser: SerializableUser = {
+  uid: "test-uid",
+  email: "test@example.com",
+  emailVerified: true,
+  displayName: "Test",
+  phoneNumber: null,
+  photoURL: null,
+};
 
 describe("LoadingScreen", () => {
   beforeEach(() => {
-    mockNavigate.mockClear();
+    resetNavigationMocks();
+    mockUseCalendarDayManager.mockReturnValue({ isLoading: false });
   });
 
   it("renders the loader", () => {
@@ -26,5 +35,43 @@ describe("LoadingScreen", () => {
       withNavigation: false,
     });
     expect(toJSON()).toBeTruthy();
+  });
+
+  it("navigates to INTRO when no user is logged in", () => {
+    renderWithProviders(<LoadingScreen />, { withNavigation: false });
+    expect(mockNavigate).toHaveBeenCalledWith(SCREENS.INTRO);
+  });
+
+  it("navigates to HOME when a user is logged in and data is ready", () => {
+    renderWithProviders(<LoadingScreen />, {
+      withNavigation: false,
+      preloadedState: {
+        auth: {
+          currentUser: testUser,
+          userUid: testUser.uid,
+          isLoggedIn: true,
+          status: "succeeded",
+          error: null,
+        },
+      },
+    });
+    expect(mockNavigate).toHaveBeenCalledWith(SCREENS.HOME);
+  });
+
+  it("does not navigate while a logged-in user's data is still loading", () => {
+    mockUseCalendarDayManager.mockReturnValue({ isLoading: true });
+    renderWithProviders(<LoadingScreen />, {
+      withNavigation: false,
+      preloadedState: {
+        auth: {
+          currentUser: testUser,
+          userUid: testUser.uid,
+          isLoggedIn: true,
+          status: "succeeded",
+          error: null,
+        },
+      },
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/screens/login-screen.test.tsx
+++ b/__tests__/screens/login-screen.test.tsx
@@ -1,26 +1,21 @@
 import React from "react";
-import { screen } from "@testing-library/react-native";
+import { Alert } from "react-native";
+import { fireEvent, screen, waitFor } from "@testing-library/react-native";
 import { LoginScreen } from "../../screens/login-screen";
 import { renderWithProviders } from "../utils/render";
 import {
   mockSignInUserMutation,
   mockSendPasswordResetMutation,
+  signInTrigger,
+  sendPasswordResetTrigger,
+  resetAuthHookMocks,
 } from "../mocks/auth-hooks";
+import { mockReplace, resetNavigationMocks } from "../mocks/navigation";
+import { SCREENS } from "../../constants/constants";
 
-const mockPush = jest.fn();
-const mockReplace = jest.fn();
-
-jest.mock("@react-navigation/native", () => {
-  const actual = jest.requireActual("@react-navigation/native");
-  return {
-    ...actual,
-    useNavigation: () => ({
-      navigate: jest.fn(),
-      replace: mockReplace,
-      push: mockPush,
-    }),
-  };
-});
+jest.mock("@react-navigation/native", () =>
+  require("../mocks/navigation").mockNavigationModule()
+);
 
 jest.mock("../../services/auth-api-rtk", () => ({
   ...jest.requireActual("../../services/auth-api-rtk"),
@@ -28,24 +23,140 @@ jest.mock("../../services/auth-api-rtk", () => ({
   useSendPasswordResetMutation: () => mockSendPasswordResetMutation(),
 }));
 
+const EMAIL_PLACEHOLDER = "Введіть вашу електронну пошту";
+const PASSWORD_PLACEHOLDER = "Введіть ваш пароль";
+
+const fillCredentials = (
+  email = "user@example.com",
+  password = "Password1"
+) => {
+  fireEvent.changeText(screen.getByPlaceholderText(EMAIL_PLACEHOLDER), email);
+  fireEvent.changeText(
+    screen.getByPlaceholderText(PASSWORD_PLACEHOLDER),
+    password
+  );
+};
+
 describe("LoginScreen", () => {
-  it("renders email and password inputs", () => {
-    renderWithProviders(<LoginScreen />);
-    expect(
-      screen.getByPlaceholderText("Введіть вашу електронну пошту")
-    ).toBeTruthy();
-    expect(
-      screen.getByPlaceholderText("Введіть ваш пароль")
-    ).toBeTruthy();
+  let alertSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    resetNavigationMocks();
+    resetAuthHookMocks();
+    alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
   });
 
-  it("renders sign-in button", () => {
-    renderWithProviders(<LoginScreen />);
-    expect(screen.getByText("Увійти")).toBeTruthy();
+  afterEach(() => {
+    alertSpy.mockRestore();
   });
 
-  it("renders forgot-password link", () => {
-    renderWithProviders(<LoginScreen />);
-    expect(screen.getByText("Забули пароль?")).toBeTruthy();
+  describe("rendering", () => {
+    it("renders email and password inputs", () => {
+      renderWithProviders(<LoginScreen />);
+      expect(screen.getByPlaceholderText(EMAIL_PLACEHOLDER)).toBeTruthy();
+      expect(screen.getByPlaceholderText(PASSWORD_PLACEHOLDER)).toBeTruthy();
+    });
+
+    it("renders sign-in and forgot-password actions", () => {
+      renderWithProviders(<LoginScreen />);
+      expect(screen.getByText("Увійти")).toBeTruthy();
+      expect(screen.getByText("Забули пароль?")).toBeTruthy();
+    });
+  });
+
+  describe("email validation", () => {
+    it("shows an error when an invalid email is blurred", () => {
+      renderWithProviders(<LoginScreen />);
+      const emailInput = screen.getByPlaceholderText(EMAIL_PLACEHOLDER);
+      fireEvent.changeText(emailInput, "not-an-email");
+      fireEvent(emailInput, "blur");
+      expect(
+        screen.getByText("Будь ласка, введіть дійсну електронну адресу")
+      ).toBeTruthy();
+    });
+
+    it("clears the error when the field is focused again", () => {
+      renderWithProviders(<LoginScreen />);
+      const emailInput = screen.getByPlaceholderText(EMAIL_PLACEHOLDER);
+      fireEvent.changeText(emailInput, "not-an-email");
+      fireEvent(emailInput, "blur");
+      fireEvent(emailInput, "focus");
+      expect(
+        screen.queryByText("Будь ласка, введіть дійсну електронну адресу")
+      ).toBeNull();
+    });
+  });
+
+  describe("sign in", () => {
+    it("submits credentials, stores the user and navigates home", async () => {
+      const { store } = renderWithProviders(<LoginScreen />);
+      fillCredentials();
+
+      fireEvent.press(screen.getByText("Увійти"));
+
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalledWith(SCREENS.HOME);
+      });
+      expect(signInTrigger).toHaveBeenCalledWith({
+        email: "user@example.com",
+        password: "Password1",
+      });
+      expect(store.getState().auth.isLoggedIn).toBe(true);
+      expect(store.getState().auth.currentUser?.uid).toBe("test-uid");
+    });
+
+    it("records an auth error and alerts when sign-in fails", async () => {
+      signInTrigger.mockImplementationOnce(() => ({
+        unwrap: () => Promise.reject(new Error("Invalid credentials")),
+      }));
+
+      const { store } = renderWithProviders(<LoginScreen />);
+      fillCredentials();
+
+      fireEvent.press(screen.getByText("Увійти"));
+
+      await waitFor(() => {
+        expect(store.getState().auth.error).toBe("Invalid credentials");
+      });
+      expect(store.getState().auth.status).toBe("failed");
+      expect(alertSpy).toHaveBeenCalledWith("Помилка", "Invalid credentials");
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("password reset", () => {
+    it("blocks reset and alerts when email is empty", async () => {
+      renderWithProviders(<LoginScreen />);
+
+      fireEvent.press(screen.getByText("Забули пароль?"));
+
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalledWith(
+          "Помилка",
+          "Введіть вашу електронну адресу, щоб отримати інструкції."
+        );
+      });
+      expect(sendPasswordResetTrigger).not.toHaveBeenCalled();
+    });
+
+    it("sends a reset request for a valid email", async () => {
+      renderWithProviders(<LoginScreen />);
+      fireEvent.changeText(
+        screen.getByPlaceholderText(EMAIL_PLACEHOLDER),
+        "user@example.com"
+      );
+
+      fireEvent.press(screen.getByText("Забули пароль?"));
+
+      await waitFor(() => {
+        expect(sendPasswordResetTrigger).toHaveBeenCalledWith({
+          email: "user@example.com",
+        });
+      });
+      expect(alertSpy).toHaveBeenCalledWith(
+        "Виконано",
+        "Ми надіслали інструкції для відновлення на user@example.com."
+      );
+    });
   });
 });

--- a/__tests__/screens/period-overview-screen.test.tsx
+++ b/__tests__/screens/period-overview-screen.test.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { fireEvent, screen } from "@testing-library/react-native";
+import PeriodOverviewScreen from "../../screens/period-overview-screen";
+import { renderWithProviders } from "../utils/render";
+import { loggedInPreloadedState } from "../utils/day-task-helpers";
+import { mockNavigate, resetNavigationMocks } from "../mocks/navigation";
+import { SCREENS } from "../../constants/constants";
+
+jest.mock("@react-navigation/native", () =>
+  require("../mocks/navigation").mockNavigationModule()
+);
+
+const mockRefresh = jest.fn();
+const mockGetDayConfig = jest.fn();
+
+jest.mock("../../hooks/useCalendarDayManager", () => ({
+  useCalendarDayManager: () => ({
+    refresh: mockRefresh,
+    isLoading: false,
+    getDayConfig: mockGetDayConfig,
+    isAdmin: false,
+  }),
+}));
+
+jest.mock("../../hooks/useCurrentDate", () => ({
+  useCurrentDate: () => ["2025-12-15", jest.fn()],
+}));
+
+jest.mock("../../components/calendar/calendar", () => ({
+  Calendar: ({
+    pressHandler,
+  }: {
+    pressHandler: (date: string) => void;
+  }) => {
+    const { Pressable, Text } = require("react-native");
+    return (
+      <Pressable
+        testID="calendar-press"
+        onPress={() => pressHandler("2025-12-01")}
+      >
+        <Text>CalendarMock</Text>
+      </Pressable>
+    );
+  },
+}));
+
+const mockUseIAP = jest.fn(() => ({
+  isSubscriber: false,
+  isSubscriptionResolved: true,
+}));
+
+jest.mock("../../hooks/useIAP", () => ({
+  useIAP: () => mockUseIAP(),
+}));
+
+describe("PeriodOverviewScreen", () => {
+  beforeEach(() => {
+    resetNavigationMocks();
+    mockRefresh.mockClear();
+    mockUseIAP.mockReturnValue({
+      isSubscriber: false,
+      isSubscriptionResolved: true,
+    });
+  });
+
+  it("renders the calendar", () => {
+    renderWithProviders(<PeriodOverviewScreen />, {
+      preloadedState: loggedInPreloadedState,
+    });
+    expect(screen.getByText("CalendarMock")).toBeTruthy();
+  });
+
+  it("navigates to the day overview when a calendar day is pressed", () => {
+    renderWithProviders(<PeriodOverviewScreen />, {
+      preloadedState: loggedInPreloadedState,
+    });
+    fireEvent.press(screen.getByTestId("calendar-press"));
+    expect(mockNavigate).toHaveBeenCalledWith("DayOverview", {
+      currentDay: "2025-12-01",
+    });
+  });
+
+  it("shows the paywall banner for non-subscribers on the current year", () => {
+    renderWithProviders(<PeriodOverviewScreen />, {
+      preloadedState: loggedInPreloadedState,
+    });
+    expect(screen.getByText("Відкрий усі дні з Jingle Plan+")).toBeTruthy();
+    expect(screen.getByText("Оформити підписку")).toBeTruthy();
+  });
+
+  it("hides the paywall banner for subscribers", () => {
+    mockUseIAP.mockReturnValue({
+      isSubscriber: true,
+      isSubscriptionResolved: true,
+    });
+
+    renderWithProviders(<PeriodOverviewScreen />, {
+      preloadedState: loggedInPreloadedState,
+    });
+    expect(screen.queryByText("Відкрий усі дні з Jingle Plan+")).toBeNull();
+  });
+
+  it("navigates to the paywall screen from the banner", () => {
+    renderWithProviders(<PeriodOverviewScreen />, {
+      preloadedState: loggedInPreloadedState,
+    });
+    fireEvent.press(screen.getByText("Оформити підписку"));
+    expect(mockNavigate).toHaveBeenCalledWith(SCREENS.PAYWALL);
+  });
+});

--- a/__tests__/screens/plans-screen.test.tsx
+++ b/__tests__/screens/plans-screen.test.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import { fireEvent, screen } from "@testing-library/react-native";
+import { PlansScreen } from "../../screens/plans-screen/plans-screen";
+import { renderWithProviders } from "../utils/render";
+import { loggedInPreloadedState } from "../utils/day-task-helpers";
+import {
+  mockGetUserDataQuery,
+  mockSaveTaskByCategoryMutation,
+  resetApiHookMocks,
+} from "../mocks/api-hooks";
+
+jest.mock("../../services/api", () => ({
+  ...jest.requireActual("../../services/api"),
+  useGetUserDataQuery: (...args: unknown[]) => mockGetUserDataQuery(...args),
+  useSaveTaskByCategoryMutation: () => mockSaveTaskByCategoryMutation(),
+  useLazyGetUserDataQuery: () => [
+    jest.fn(() => ({ unwrap: () => Promise.resolve(null) })),
+    { isLoading: false },
+  ],
+}));
+
+jest.mock("../../components/modals/month-select-modal", () => ({
+  MonthSelectModal: () => null,
+}));
+
+const setUserData = (data: unknown) => {
+  mockGetUserDataQuery.mockReturnValue({
+    data,
+    isLoading: false,
+    isFetching: false,
+    error: undefined,
+    refetch: jest.fn(),
+  });
+};
+
+describe("PlansScreen", () => {
+  beforeEach(() => {
+    resetApiHookMocks();
+  });
+
+  it("shows the empty screen when there are no plans or global goal", () => {
+    setUserData(null);
+    renderWithProviders(<PlansScreen />, {
+      preloadedState: loggedInPreloadedState,
+    });
+    expect(screen.getByText("Поки що тут нічого немає")).toBeTruthy();
+  });
+
+  it("shows the global goal when only goals exist", () => {
+    setUserData({
+      goals: { globalGoal: { id: "g1", text: "Run a marathon" } },
+    });
+    renderWithProviders(<PlansScreen />, {
+      preloadedState: loggedInPreloadedState,
+    });
+    expect(screen.getByText("Run a marathon")).toBeTruthy();
+    expect(screen.getByText("Моя глобальна мета 2026:")).toBeTruthy();
+    expect(screen.queryByTestId("view-switch-selector")).toBeNull();
+  });
+
+  describe("with plans", () => {
+    beforeEach(() => {
+      setUserData({
+        plans: {
+          health: [
+            { id: "h1", text: "Morning run", isDone: false },
+            { id: "h2", text: "Yoga session", isDone: true },
+          ],
+        },
+        goals: { globalGoal: { id: "g1", text: "Stay healthy" } },
+      });
+    });
+
+    it("renders the view switch, global goal, and context headers", () => {
+      renderWithProviders(<PlansScreen />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      expect(screen.getByTestId("view-switch-selector")).toBeTruthy();
+      expect(screen.getByText("По сферах")).toBeTruthy();
+      expect(screen.getByText("По місяцях")).toBeTruthy();
+      expect(screen.getByText("Stay healthy")).toBeTruthy();
+      expect(screen.getByText("Тіло")).toBeTruthy();
+    });
+
+    it("opens the add-plan modal when the FAB is pressed", () => {
+      renderWithProviders(<PlansScreen />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      const buttons = screen.getAllByRole("button");
+      fireEvent.press(buttons[buttons.length - 1]);
+      expect(screen.getByText("Додайте один пункт плану")).toBeTruthy();
+    });
+  });
+});

--- a/__tests__/screens/register-screen.test.tsx
+++ b/__tests__/screens/register-screen.test.tsx
@@ -1,26 +1,24 @@
 import React from "react";
-import { screen } from "@testing-library/react-native";
+import { Alert, AlertButton } from "react-native";
+import { fireEvent, screen, waitFor } from "@testing-library/react-native";
 import { RegisterScreen } from "../../screens/register-screen";
 import { renderWithProviders } from "../utils/render";
 import {
   mockCreateUserMutation,
+  createUserTrigger,
+  resetAuthHookMocks,
 } from "../mocks/auth-hooks";
-import { mockCreateProfileMutation } from "../mocks/api-hooks";
+import {
+  mockCreateProfileMutation,
+  createProfileTrigger,
+  resetApiHookMocks,
+} from "../mocks/api-hooks";
+import { mockReplace, resetNavigationMocks } from "../mocks/navigation";
+import { SCREENS } from "../../constants/constants";
 
-const mockPush = jest.fn();
-const mockReplace = jest.fn();
-
-jest.mock("@react-navigation/native", () => {
-  const actual = jest.requireActual("@react-navigation/native");
-  return {
-    ...actual,
-    useNavigation: () => ({
-      navigate: jest.fn(),
-      replace: mockReplace,
-      push: mockPush,
-    }),
-  };
-});
+jest.mock("@react-navigation/native", () =>
+  require("../mocks/navigation").mockNavigationModule()
+);
 
 jest.mock("../../services/auth-api-rtk", () => ({
   ...jest.requireActual("../../services/auth-api-rtk"),
@@ -32,17 +30,145 @@ jest.mock("../../services/api", () => ({
   useCreateProfileMutation: () => mockCreateProfileMutation(),
 }));
 
+const NAME_PLACEHOLDER = "Ім'я";
+const EMAIL_PLACEHOLDER = "Пошта";
+const PASSWORD_PLACEHOLDER = "Пароль";
+const REPEAT_PLACEHOLDER = "Повторіть пароль";
+
+const fillForm = ({
+  name = "Anna",
+  email = "anna@example.com",
+  password = "Password1",
+  repeat = "Password1",
+}: Partial<{
+  name: string;
+  email: string;
+  password: string;
+  repeat: string;
+}> = {}) => {
+  fireEvent.changeText(screen.getByPlaceholderText(NAME_PLACEHOLDER), name);
+  fireEvent.changeText(screen.getByPlaceholderText(EMAIL_PLACEHOLDER), email);
+  fireEvent.changeText(
+    screen.getByPlaceholderText(PASSWORD_PLACEHOLDER),
+    password
+  );
+  fireEvent.changeText(
+    screen.getByPlaceholderText(REPEAT_PLACEHOLDER),
+    repeat
+  );
+};
+
 describe("RegisterScreen", () => {
-  it("renders registration form fields", () => {
-    renderWithProviders(<RegisterScreen />);
-    expect(screen.getByText("Ім'я")).toBeTruthy();
-    expect(screen.getByText("Пошта")).toBeTruthy();
-    expect(screen.getAllByText("Пароль").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText("Повторіть пароль")).toBeTruthy();
+  let alertSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    resetNavigationMocks();
+    resetAuthHookMocks();
+    resetApiHookMocks();
+    alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
   });
 
-  it("renders create account button", () => {
-    renderWithProviders(<RegisterScreen />);
-    expect(screen.getByText("Створити акаунт")).toBeTruthy();
+  afterEach(() => {
+    alertSpy.mockRestore();
+  });
+
+  describe("rendering", () => {
+    it("renders the form fields and submit button", () => {
+      renderWithProviders(<RegisterScreen />);
+      expect(screen.getByPlaceholderText(NAME_PLACEHOLDER)).toBeTruthy();
+      expect(screen.getByPlaceholderText(EMAIL_PLACEHOLDER)).toBeTruthy();
+      expect(screen.getByPlaceholderText(REPEAT_PLACEHOLDER)).toBeTruthy();
+      expect(screen.getByText("Створити акаунт")).toBeTruthy();
+    });
+  });
+
+  describe("validation", () => {
+    it("shows a password error for a weak password", () => {
+      renderWithProviders(<RegisterScreen />);
+      fireEvent.changeText(
+        screen.getByPlaceholderText(PASSWORD_PLACEHOLDER),
+        "weak"
+      );
+      expect(
+        screen.getByText(
+          "Пароль має складатись із щонайменше 8 символів і містити хоча б одну цифру та хоча б одну велику літеру"
+        )
+      ).toBeTruthy();
+    });
+
+    it("shows a mismatch error when passwords differ", () => {
+      renderWithProviders(<RegisterScreen />);
+      fireEvent.changeText(
+        screen.getByPlaceholderText(PASSWORD_PLACEHOLDER),
+        "Password1"
+      );
+      fireEvent.changeText(
+        screen.getByPlaceholderText(REPEAT_PLACEHOLDER),
+        "Password2"
+      );
+      expect(screen.getByText("Паролі не збігаються")).toBeTruthy();
+    });
+
+    it("shows a name error when name is blurred empty", () => {
+      renderWithProviders(<RegisterScreen />);
+      const nameInput = screen.getByPlaceholderText(NAME_PLACEHOLDER);
+      fireEvent.changeText(nameInput, "   ");
+      fireEvent(nameInput, "blur");
+      expect(screen.getByText("Ім'я обов'язкове")).toBeTruthy();
+    });
+
+    it("does not submit when validation errors are present", () => {
+      renderWithProviders(<RegisterScreen />);
+      fillForm({ password: "weak", repeat: "weak" });
+      fireEvent.press(screen.getByText("Створити акаунт"));
+      expect(createUserTrigger).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("submit", () => {
+    it("creates the user and profile, then navigates home", async () => {
+      alertSpy.mockImplementation(
+        (_title?: string, _msg?: string, buttons?: AlertButton[]) => {
+          buttons?.[1]?.onPress?.();
+        }
+      );
+
+      const { store } = renderWithProviders(<RegisterScreen />);
+      fillForm();
+
+      fireEvent.press(screen.getByText("Створити акаунт"));
+
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalledWith(SCREENS.HOME);
+      });
+      expect(createUserTrigger).toHaveBeenCalledWith({
+        email: "anna@example.com",
+        password: "Password1",
+      });
+      expect(createProfileTrigger).toHaveBeenCalledWith({
+        uid: "new-uid",
+        name: "Anna",
+        email: "test@example.com",
+      });
+      expect(store.getState().auth.isLoggedIn).toBe(true);
+    });
+
+    it("records an auth error and alerts when creation fails", async () => {
+      createUserTrigger.mockImplementationOnce(() => ({
+        unwrap: () => Promise.reject(new Error("Email already in use")),
+      }));
+
+      const { store } = renderWithProviders(<RegisterScreen />);
+      fillForm();
+
+      fireEvent.press(screen.getByText("Створити акаунт"));
+
+      await waitFor(() => {
+        expect(store.getState().auth.error).toBe("Email already in use");
+      });
+      expect(store.getState().auth.status).toBe("failed");
+      expect(alertSpy).toHaveBeenCalledWith("Помилка", "Email already in use");
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
   });
 });

--- a/__tests__/screens/summary-screen.test.tsx
+++ b/__tests__/screens/summary-screen.test.tsx
@@ -1,0 +1,136 @@
+import React from "react";
+import { Alert } from "react-native";
+import { fireEvent, screen, waitFor } from "@testing-library/react-native";
+import { SummaryScreen } from "../../screens/summary-screen/summary-screen";
+import { renderWithProviders } from "../utils/render";
+import { loggedInPreloadedState } from "../utils/day-task-helpers";
+import {
+  mockGetUserDataQuery,
+  mockSaveTaskByCategoryMutation,
+  mockRemoveTaskMutation,
+  saveTaskByCategoryTrigger,
+  removeTaskTrigger,
+  resetApiHookMocks,
+} from "../mocks/api-hooks";
+import { TASK_CATEGORY } from "../../constants/constants";
+
+jest.mock("../../services/api", () => ({
+  ...jest.requireActual("../../services/api"),
+  useGetUserDataQuery: (...args: unknown[]) => mockGetUserDataQuery(...args),
+  useSaveTaskByCategoryMutation: () => mockSaveTaskByCategoryMutation(),
+  useRemoveTaskMutation: () => mockRemoveTaskMutation(),
+}));
+
+jest.mock("../../hooks/useUnsavedChangesBlocker", () => ({
+  useUnsavedChangesBlocker: jest.fn(),
+}));
+
+const TEXTAREA_PLACEHOLDER = "Напишить щось тут";
+
+const setUserData = (data: unknown) => {
+  mockGetUserDataQuery.mockReturnValue({
+    data,
+    isLoading: false,
+    isFetching: false,
+    error: undefined,
+    refetch: jest.fn(),
+  });
+};
+
+describe("SummaryScreen", () => {
+  let alertSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    resetApiHookMocks();
+    alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
+  });
+
+  it("shows the empty screen when there is no summary data", () => {
+    setUserData(null);
+    renderWithProviders(<SummaryScreen />, {
+      preloadedState: loggedInPreloadedState,
+    });
+    expect(screen.getByText("Поки що тут нічого немає")).toBeTruthy();
+  });
+
+  describe("with summary data", () => {
+    beforeEach(() => {
+      setUserData({
+        summary: {
+          health: { id: "s1", text: "Health reflection", rate: 75 },
+          work: { id: "s2", text: "Work reflection", rate: 50 },
+        },
+      });
+    });
+
+    it("renders accordion headers for contexts with data", () => {
+      renderWithProviders(<SummaryScreen />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      expect(screen.getByText("Тіло")).toBeTruthy();
+      expect(screen.getByText("Сродна праця")).toBeTruthy();
+    });
+
+    it("shows summary text after expanding a section", () => {
+      renderWithProviders(<SummaryScreen />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      fireEvent.press(screen.getByText("Тіло"));
+      expect(screen.getByText("Health reflection")).toBeTruthy();
+      expect(screen.getAllByText("Редагувати").length).toBeGreaterThan(0);
+    });
+
+    it("enters edit mode, saves updated text, and calls the mutation", async () => {
+      renderWithProviders(<SummaryScreen />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      fireEvent.press(screen.getByText("Тіло"));
+      fireEvent.press(screen.getAllByText("Редагувати")[0]);
+      fireEvent.changeText(
+        screen.getByPlaceholderText(TEXTAREA_PLACEHOLDER),
+        "Updated health reflection"
+      );
+      fireEvent.press(screen.getByText("Готово"));
+
+      await waitFor(() => {
+        expect(saveTaskByCategoryTrigger).toHaveBeenCalledWith(
+          expect.objectContaining({
+            category: TASK_CATEGORY.SUMMARY,
+            context: "health",
+            year: "2025",
+            data: expect.objectContaining({
+              text: "Updated health reflection",
+              rate: 75,
+            }),
+          })
+        );
+      });
+    });
+
+    it("removes a summary after delete confirmation", async () => {
+      alertSpy.mockImplementation(
+        (_title?: string, _msg?: string, buttons?: { onPress?: () => void }[]) => {
+          buttons?.[1]?.onPress?.();
+        }
+      );
+
+      renderWithProviders(<SummaryScreen />, {
+        preloadedState: loggedInPreloadedState,
+      });
+      fireEvent.press(screen.getByText("Тіло"));
+      fireEvent.press(screen.getAllByText("Видалити")[0]);
+
+      await waitFor(() => {
+        expect(removeTaskTrigger).toHaveBeenCalledWith({
+          category: TASK_CATEGORY.SUMMARY,
+          context: "health",
+          year: "2025",
+        });
+      });
+    });
+  });
+});

--- a/__tests__/store/appReducer.test.ts
+++ b/__tests__/store/appReducer.test.ts
@@ -1,0 +1,43 @@
+import appReducer, {
+  setSelectedYear,
+  setConfiguration,
+  selectSelectedYear,
+} from "../../store/appReducer";
+import { YEARS } from "../../constants/constants";
+import type { CalendarConfig } from "../../types/types";
+
+const initialState = appReducer(undefined, { type: "@@INIT" });
+
+describe("appReducer", () => {
+  it("defaults the selected year to the latest configured year", () => {
+    expect(initialState.selectedYear).toBe(YEARS[YEARS.length - 1]);
+    expect(initialState.configuration).toBeNull();
+    expect(initialState.status).toBe("idle");
+  });
+
+  it("updates the selected year", () => {
+    const state = appReducer(initialState, setSelectedYear("2024"));
+    expect(state.selectedYear).toBe("2024");
+  });
+
+  it("stores the configuration", () => {
+    const config = { foo: "bar" } as unknown as CalendarConfig;
+    const state = appReducer(initialState, setConfiguration(config));
+    expect(state.configuration).toBe(config);
+  });
+
+  it("clears the configuration when set to null", () => {
+    const withConfig = appReducer(
+      initialState,
+      setConfiguration({ foo: "bar" } as unknown as CalendarConfig)
+    );
+    const state = appReducer(withConfig, setConfiguration(null));
+    expect(state.configuration).toBeNull();
+  });
+
+  it("selectSelectedYear reads the slice", () => {
+    expect(selectSelectedYear({ app: initialState })).toBe(
+      YEARS[YEARS.length - 1]
+    );
+  });
+});

--- a/__tests__/store/authReducer.test.ts
+++ b/__tests__/store/authReducer.test.ts
@@ -1,0 +1,78 @@
+import authReducer, {
+  hydrateAuth,
+  setUser,
+  clearUser,
+  setAuthError,
+  setAuthLoading,
+} from "../../store/authReducer";
+import type { SerializableUser } from "../../types/user";
+
+const user: SerializableUser = {
+  uid: "uid-1",
+  email: "a@b.com",
+  emailVerified: true,
+  displayName: "Anna",
+  phoneNumber: null,
+  photoURL: null,
+};
+
+const initialState = authReducer(undefined, { type: "@@INIT" });
+
+describe("authReducer", () => {
+  it("returns the initial state", () => {
+    expect(initialState).toEqual({
+      currentUser: null,
+      userUid: null,
+      isLoggedIn: false,
+      status: "idle",
+      error: null,
+    });
+  });
+
+  it("hydrates with a user", () => {
+    const state = authReducer(initialState, hydrateAuth(user));
+    expect(state.currentUser).toEqual(user);
+    expect(state.userUid).toBe("uid-1");
+    expect(state.isLoggedIn).toBe(true);
+    expect(state.status).toBe("succeeded");
+  });
+
+  it("hydrates with null (logged out)", () => {
+    const state = authReducer(initialState, hydrateAuth(null));
+    expect(state.currentUser).toBeNull();
+    expect(state.userUid).toBeNull();
+    expect(state.isLoggedIn).toBe(false);
+    expect(state.status).toBe("succeeded");
+  });
+
+  it("sets the user and marks logged in", () => {
+    const state = authReducer(initialState, setUser(user));
+    expect(state.currentUser).toEqual(user);
+    expect(state.userUid).toBe("uid-1");
+    expect(state.isLoggedIn).toBe(true);
+    expect(state.status).toBe("succeeded");
+    expect(state.error).toBeNull();
+  });
+
+  it("clears the user", () => {
+    const loggedIn = authReducer(initialState, setUser(user));
+    const state = authReducer(loggedIn, clearUser());
+    expect(state.currentUser).toBeNull();
+    expect(state.userUid).toBeNull();
+    expect(state.isLoggedIn).toBe(false);
+    expect(state.status).toBe("idle");
+  });
+
+  it("records an auth error", () => {
+    const state = authReducer(initialState, setAuthError("bad password"));
+    expect(state.error).toBe("bad password");
+    expect(state.status).toBe("failed");
+  });
+
+  it("marks auth as pending and clears errors", () => {
+    const errored = authReducer(initialState, setAuthError("x"));
+    const state = authReducer(errored, setAuthLoading());
+    expect(state.status).toBe("pending");
+    expect(state.error).toBeNull();
+  });
+});

--- a/__tests__/utils/album-screen-test-state.ts
+++ b/__tests__/utils/album-screen-test-state.ts
@@ -1,0 +1,28 @@
+const defaultState = {
+  carouselRef: { current: null },
+  carouselSize: { width: 0, height: 0 },
+  photos: null as unknown[] | null,
+  currentMonth: "Рік",
+  handleCarouselLayout: jest.fn(),
+  handleForward: jest.fn(),
+  handleBack: jest.fn(),
+  handleSnapToItem: jest.fn(),
+};
+
+let albumScreenState = { ...defaultState };
+
+export const getAlbumScreenState = () => albumScreenState;
+
+export const setAlbumScreenState = (partial: Partial<typeof defaultState>) => {
+  albumScreenState = { ...albumScreenState, ...partial };
+};
+
+export const resetAlbumScreenState = () => {
+  albumScreenState = {
+    ...defaultState,
+    handleCarouselLayout: jest.fn(),
+    handleForward: jest.fn(),
+    handleBack: jest.fn(),
+    handleSnapToItem: jest.fn(),
+  };
+};

--- a/__tests__/utils/dashboard-utils.test.ts
+++ b/__tests__/utils/dashboard-utils.test.ts
@@ -1,0 +1,125 @@
+import {
+  calculateTotalData,
+  calculateContextData,
+  isDataEmpty,
+} from "../../utils/dashboard-utils";
+import type { PlanContextData, PlanData } from "../../types/types";
+
+const plan = (overrides: Partial<PlanData>): PlanData =>
+  ({
+    id: Math.random().toString(),
+    text: "task",
+    isDone: false,
+    ...overrides,
+  }) as PlanData;
+
+describe("calculateTotalData", () => {
+  it("returns zeroed progress for empty data", () => {
+    expect(calculateTotalData({})).toEqual({
+      totalTasks: 0,
+      doneTasks: 0,
+      donePercentage: 0,
+    });
+  });
+
+  it("counts plain tasks across contexts", () => {
+    const data: PlanContextData = {
+      health: [plan({ isDone: true }), plan({ isDone: false })],
+      work: [plan({ isDone: true })],
+    };
+    expect(calculateTotalData(data)).toEqual({
+      totalTasks: 3,
+      doneTasks: 2,
+      donePercentage: 67,
+    });
+  });
+
+  it("expands 'every' month tasks to 12 and counts monthly progress", () => {
+    const data: PlanContextData = {
+      health: [
+        plan({
+          month: "every",
+          monthlyProgress: [
+            { month: "january", isDone: true },
+            { month: "february", isDone: true },
+            { month: "march", isDone: false },
+          ],
+        }),
+      ],
+    };
+    const result = calculateTotalData(data);
+    expect(result.totalTasks).toBe(13);
+    expect(result.doneTasks).toBe(2);
+    expect(result.donePercentage).toBe(15);
+  });
+
+  it("ignores null task lists", () => {
+    const data = {
+      health: null,
+      work: [plan({ isDone: true })],
+    } as unknown as PlanContextData;
+    expect(calculateTotalData(data)).toEqual({
+      totalTasks: 1,
+      doneTasks: 1,
+      donePercentage: 100,
+    });
+  });
+});
+
+describe("calculateContextData", () => {
+  it("computes per-context progress", () => {
+    const data: PlanContextData = {
+      health: [plan({ isDone: true }), plan({ isDone: false })],
+      work: [plan({ isDone: true })],
+    };
+    const result = calculateContextData(data);
+    expect(result.health).toEqual({
+      totalTasks: 2,
+      doneTasks: 1,
+      donePercentage: 50,
+    });
+    expect(result.work).toEqual({
+      totalTasks: 1,
+      doneTasks: 1,
+      donePercentage: 100,
+    });
+  });
+
+  it("accounts for 'every' month tasks per context", () => {
+    const data: PlanContextData = {
+      learning: [
+        plan({
+          month: "every",
+          monthlyProgress: [
+            { month: "january", isDone: true },
+            { month: "february", isDone: true },
+            { month: "march", isDone: true },
+          ],
+        }),
+      ],
+    };
+    expect(calculateContextData(data).learning).toEqual({
+      totalTasks: 13,
+      doneTasks: 3,
+      donePercentage: 23,
+    });
+  });
+});
+
+describe("isDataEmpty", () => {
+  it("returns true for null", () => {
+    expect(isDataEmpty(null)).toBe(true);
+  });
+
+  it("returns true when all values are zero", () => {
+    expect(
+      isDataEmpty({ totalTasks: 0, doneTasks: 0, donePercentage: 0 })
+    ).toBe(true);
+  });
+
+  it("returns false when there is any progress", () => {
+    expect(
+      isDataEmpty({ totalTasks: 5, doneTasks: 0, donePercentage: 0 })
+    ).toBe(false);
+  });
+});

--- a/__tests__/utils/day-overview-test-state.ts
+++ b/__tests__/utils/day-overview-test-state.ts
@@ -1,0 +1,25 @@
+let dayOverviewState = {
+  dayTasks: null as unknown,
+  total: 0,
+  error: null as unknown,
+  refresh: jest.fn(),
+  isLoading: false,
+};
+
+export const getDayOverviewState = () => dayOverviewState;
+
+export const setDayOverviewState = (
+  partial: Partial<typeof dayOverviewState>
+) => {
+  dayOverviewState = { ...dayOverviewState, ...partial };
+};
+
+export const resetDayOverviewState = () => {
+  dayOverviewState = {
+    dayTasks: null,
+    total: 0,
+    error: null,
+    refresh: jest.fn(),
+    isLoading: false,
+  };
+};

--- a/__tests__/utils/day-task-helpers.ts
+++ b/__tests__/utils/day-task-helpers.ts
@@ -1,0 +1,65 @@
+import type { ImageData } from "../../types/types";
+import type { RootState } from "../../store/store";
+import type { SerializableUser } from "../../types/user";
+
+export const testUser: SerializableUser = {
+  uid: "test-uid",
+  email: "test@example.com",
+  emailVerified: true,
+  displayName: "Test User",
+  phoneNumber: null,
+  photoURL: null,
+};
+
+export const loggedInPreloadedState: Partial<RootState> = {
+  auth: {
+    currentUser: testUser,
+    userUid: testUser.uid,
+    isLoggedIn: true,
+    status: "succeeded",
+    error: null,
+  },
+  app: {
+    selectedYear: "2025",
+    configuration: null,
+    status: "idle",
+    error: null,
+  },
+};
+
+export let mockImage: ImageData | null = null;
+
+export const mockSetImage = jest.fn((image: ImageData | null) => {
+  mockImage = image;
+});
+
+export const mockSaveImageFn = jest.fn(() =>
+  Promise.resolve("https://example.com/image.jpg")
+);
+
+export const mockSetIsLoading = jest.fn();
+
+export const mockUseImage = jest.fn(() => ({
+  saveImage: mockSaveImageFn,
+  setImage: mockSetImage,
+  get image() {
+    return mockImage;
+  },
+  isLoading: false,
+  setIsLoading: mockSetIsLoading,
+}));
+
+export const resetImageMock = () => {
+  mockImage = null;
+  mockSetImage.mockClear();
+  mockSaveImageFn.mockClear();
+  mockSetIsLoading.mockClear();
+  mockUseImage.mockClear();
+};
+
+export const testImage: ImageData = {
+  id: "img-1",
+  uri: "file://photo.jpg",
+  width: 100,
+  height: 100,
+};

--- a/__tests__/utils/group-plans-by-month.test.ts
+++ b/__tests__/utils/group-plans-by-month.test.ts
@@ -1,0 +1,47 @@
+import {
+  groupPlansByMonth,
+} from "../../components/plans-view/month-view/helpers";
+import type { PlansCollection } from "../../types/types";
+
+describe("groupPlansByMonth", () => {
+  it("returns an empty object for empty plans", () => {
+    expect(groupPlansByMonth({})).toEqual({});
+  });
+
+  it("groups plans by their month", () => {
+    const plans: PlansCollection = {
+      health: [
+        { id: "h1", text: "Run", isDone: false, month: "january", context: "health" },
+        { id: "h2", text: "Swim", isDone: false, month: "march", context: "health" },
+      ],
+    };
+
+    const result = groupPlansByMonth(plans);
+    expect(result.january).toHaveLength(1);
+    expect(result.january?.[0].text).toBe("Run");
+    expect(result.march).toHaveLength(1);
+  });
+
+  it("expands every-month plans into each monthly bucket", () => {
+    const plans: PlansCollection = {
+      work: [
+        {
+          id: "w1",
+          text: "Daily standup",
+          isDone: false,
+          month: "every",
+          context: "work",
+          monthlyProgress: [
+            { month: "january", isDone: false },
+            { month: "february", isDone: true },
+          ],
+        },
+      ],
+    };
+
+    const result = groupPlansByMonth(plans);
+    expect(result.january).toHaveLength(1);
+    expect(result.february).toHaveLength(1);
+    expect(result.january?.[0].context).toBe("work");
+  });
+});

--- a/__tests__/utils/map-data-to-carousel.test.ts
+++ b/__tests__/utils/map-data-to-carousel.test.ts
@@ -1,0 +1,42 @@
+import { mapDataToCarousel } from "../../screens/album-screen/map-data-to-carousel";
+import type { MonthPhotoData } from "../../types/types";
+
+describe("mapDataToCarousel", () => {
+  it("returns an empty array for empty input", () => {
+    expect(mapDataToCarousel({})).toEqual([]);
+  });
+
+  it("maps month entries and sorts by album month order", () => {
+    const data: MonthPhotoData = {
+      march: {
+        id: "m3",
+        text: "March photo",
+        image: { id: "img3", uri: "file://march.jpg" },
+      },
+      january: {
+        id: "m1",
+        text: "January photo",
+        image: { id: "img1", uri: "file://jan.jpg" },
+      },
+    };
+
+    const result = mapDataToCarousel(data);
+    expect(result).toHaveLength(2);
+    expect(result[0].month).toBe("january");
+    expect(result[0].text).toBe("January photo");
+    expect(result[1].month).toBe("march");
+  });
+
+  it("skips null month entries", () => {
+    const data = {
+      january: {
+        id: "m1",
+        text: "Only month",
+        image: null,
+      },
+      february: undefined,
+    } as MonthPhotoData;
+
+    expect(mapDataToCarousel(data)).toHaveLength(1);
+  });
+});

--- a/__tests__/utils/plans-utils.test.ts
+++ b/__tests__/utils/plans-utils.test.ts
@@ -1,0 +1,40 @@
+import { findPlanContextById, getPlansList } from "../../utils/plans-utils";
+import type { PlanScreenData, PlansCollection } from "../../types/types";
+
+const makePlan = (id: string, context: string): PlanScreenData =>
+  ({
+    id,
+    context,
+    text: `plan-${id}`,
+    isDone: false,
+  }) as unknown as PlanScreenData;
+
+const plans: PlansCollection = {
+  health: [makePlan("h1", "health"), makePlan("h2", "health")],
+  work: [makePlan("w1", "work")],
+};
+
+describe("findPlanContextById", () => {
+  it("finds the context that owns a plan id", () => {
+    expect(findPlanContextById(plans, "h2")).toBe("health");
+    expect(findPlanContextById(plans, "w1")).toBe("work");
+  });
+
+  it("returns null when no plan matches", () => {
+    expect(findPlanContextById(plans, "missing")).toBeNull();
+  });
+});
+
+describe("getPlansList", () => {
+  it("returns the list for a context", () => {
+    expect(getPlansList(plans, "health")).toHaveLength(2);
+  });
+
+  it("returns an empty array for an empty context", () => {
+    expect(getPlansList(plans, "relax")).toEqual([]);
+  });
+
+  it("returns an empty array when plans is null", () => {
+    expect(getPlansList(null, "health")).toEqual([]);
+  });
+});

--- a/__tests__/utils/render.tsx
+++ b/__tests__/utils/render.tsx
@@ -84,3 +84,17 @@ export function renderWithProviders(
 
   return { ...result, store };
 }
+
+export function createHookWrapper(preloadedState?: Partial<RootState>) {
+  const store = createTestStore(preloadedState);
+
+  return function HookWrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <Provider store={store}>
+        <SafeAreaProvider>
+          <GluestackUIProvider config={config}>{children}</GluestackUIProvider>
+        </SafeAreaProvider>
+      </Provider>
+    );
+  };
+}

--- a/__tests__/utils/utils.test.ts
+++ b/__tests__/utils/utils.test.ts
@@ -1,0 +1,98 @@
+import {
+  getProgressColorByValue,
+  calculateTotalProgress,
+  getPluralForm,
+  resolveErrorMessage,
+} from "../../utils/utils";
+
+describe("getProgressColorByValue", () => {
+  it("returns red below 30", () => {
+    expect(getProgressColorByValue(0)).toBe("$progressRed");
+    expect(getProgressColorByValue(29)).toBe("$progressRed");
+  });
+
+  it("returns yellow between 30 and 69", () => {
+    expect(getProgressColorByValue(30)).toBe("$progressYellow");
+    expect(getProgressColorByValue(69)).toBe("$progressYellow");
+  });
+
+  it("returns green at 70 and above", () => {
+    expect(getProgressColorByValue(70)).toBe("$green400");
+    expect(getProgressColorByValue(100)).toBe("$green400");
+  });
+});
+
+describe("calculateTotalProgress", () => {
+  it("returns 0 when progress is undefined", () => {
+    expect(calculateTotalProgress()).toBe(0);
+  });
+
+  it("sums the task grades", () => {
+    expect(
+      calculateTotalProgress({ dayTaskGrade: 40, moodTaskGrade: 35 })
+    ).toBe(75);
+  });
+
+  it("handles zeroed progress", () => {
+    expect(
+      calculateTotalProgress({ dayTaskGrade: 0, moodTaskGrade: 0 })
+    ).toBe(0);
+  });
+});
+
+describe("getPluralForm", () => {
+  const ukDictionary: Record<string, string> = {
+    "screens.dashboardScreen.tasksSingular": "ціль",
+    "screens.dashboardScreen.tasksFew": "цілі",
+    "screens.dashboardScreen.tasksPlural": "цілей",
+  };
+  const enDictionary: Record<string, string> = {
+    "screens.dashboardScreen.tasksSingular": "goal",
+    "screens.dashboardScreen.tasksFew": "goals",
+    "screens.dashboardScreen.tasksPlural": "goals",
+  };
+  const uk = (key: string) => ukDictionary[key];
+  const en = (key: string) => enDictionary[key];
+
+  it("applies Ukrainian rules", () => {
+    expect(getPluralForm(1, uk)).toBe("ціль");
+    expect(getPluralForm(2, uk)).toBe("цілі");
+    expect(getPluralForm(4, uk)).toBe("цілі");
+    expect(getPluralForm(5, uk)).toBe("цілей");
+    expect(getPluralForm(11, uk)).toBe("цілей");
+    expect(getPluralForm(19, uk)).toBe("цілей");
+    expect(getPluralForm(21, uk)).toBe("ціль");
+    expect(getPluralForm(0, uk)).toBe("цілей");
+  });
+
+  it("applies English rules", () => {
+    expect(getPluralForm(1, en)).toBe("goal");
+    expect(getPluralForm(0, en)).toBe("goals");
+    expect(getPluralForm(2, en)).toBe("goals");
+  });
+});
+
+describe("resolveErrorMessage", () => {
+  it("returns a plain string error", () => {
+    expect(resolveErrorMessage("boom")).toBe("boom");
+  });
+
+  it("returns the message of an Error instance", () => {
+    expect(resolveErrorMessage(new Error("failed"))).toBe("failed");
+  });
+
+  it("reads a string data field (RTK style)", () => {
+    expect(resolveErrorMessage({ data: "server error" })).toBe("server error");
+  });
+
+  it("reads a nested data.message field", () => {
+    expect(
+      resolveErrorMessage({ data: { message: "nested error" } })
+    ).toBe("nested error");
+  });
+
+  it("returns null for unrecognized shapes", () => {
+    expect(resolveErrorMessage(undefined)).toBeNull();
+    expect(resolveErrorMessage({ foo: "bar" })).toBeNull();
+  });
+});

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,9 +1,10 @@
 module.exports = function (api) {
-  api.cache(true);
+  api.cache.using(() => process.env.NODE_ENV);
+  const isTest = process.env.NODE_ENV === "test";
   return {
     presets: ["babel-preset-expo"],
     plugins: [
-      ["module:react-native-dotenv"],
+      ...(isTest ? [] : [["module:react-native-dotenv"]]),
       "react-native-reanimated/plugin", // THIS HAS TO BE LISTED LAST
     ],
   };

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,4 +9,20 @@ module.exports = {
     "^@env$": "<rootDir>/__tests__/mocks/env.ts",
   },
   testPathIgnorePatterns: ["/node_modules/", "/firebase/"],
+  collectCoverageFrom: [
+    "components/**/*.{ts,tsx}",
+    "screens/**/*.{ts,tsx}",
+    "store/**/*.{ts,tsx}",
+    "utils/**/*.{ts,tsx}",
+    "hooks/**/*.{ts,tsx}",
+    "services/**/*.{ts,tsx}",
+    "!**/*.d.ts",
+    "!**/index.{ts,tsx}",
+    "!config/**",
+  ],
+  coveragePathIgnorePatterns: [
+    "/node_modules/",
+    "/__tests__/",
+    "/firebase/",
+  ],
 };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -50,7 +50,7 @@ jest.mock("@react-native-firebase/storage", () => ({
 }));
 
 jest.mock("expo-haptics", () => ({
-  impactAsync: jest.fn(),
+  impactAsync: jest.fn(() => Promise.resolve()),
   ImpactFeedbackStyle: { Light: "light", Medium: "medium" },
 }));
 


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to run Jest with coverage on pull requests to `main`
- Fix Jest coverage collection under the test environment (babel dotenv issue)
- Expand the suite from smoke tests to behavior coverage across auth, day-tasks,
  dashboard, plans, summary, album, and overview screens
- Add hook, reducer, and utility tests with shared mocks and test helpers

## Test plan
- [x] Verify Test workflow passes on this PR with coverage reporting
- [ ] Review coverage summary in CI output (~52% statements)
- [ ] Add `test` as a required status check in branch protection after merge