### PR TITLE
fix: migrate remaining Firebase calls to modular API

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -23,6 +23,7 @@ jest.mock("@react-native-firebase/app", () => ({
 jest.mock("@react-native-firebase/auth", () => ({
   getAuth: jest.fn(() => ({ currentUser: null })),
   createUserWithEmailAndPassword: jest.fn(),
+  deleteUser: jest.fn(),
   signInWithEmailAndPassword: jest.fn(),
   signOut: jest.fn(),
   sendPasswordResetEmail: jest.fn(),
@@ -34,6 +35,7 @@ jest.mock("@react-native-firebase/database", () => ({
   ref: jest.fn(),
   remove: jest.fn(),
   set: jest.fn(),
+  update: jest.fn(),
 }));
 
 jest.mock("@react-native-firebase/messaging", () => ({

--- a/services/auth-api-rtk.ts
+++ b/services/auth-api-rtk.ts
@@ -1,6 +1,7 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
 import {
   createUserWithEmailAndPassword,
+  deleteUser,
   FirebaseAuthTypes,
   getAuth,
   sendPasswordResetEmail,
@@ -52,7 +53,7 @@ const authQuery = async (args: any) => {
         if (!user) {
           throw new Error("No user is currently logged in");
         }
-        await user.delete();
+        await deleteUser(user);
         return { data: null };
       }
 

--- a/services/messaging.ts
+++ b/services/messaging.ts
@@ -1,4 +1,9 @@
-import { getDatabase, ref } from "@react-native-firebase/database";
+import {
+  getDatabase,
+  ref,
+  remove,
+  update,
+} from "@react-native-firebase/database";
 import { getAuth } from "@react-native-firebase/auth";
 import {
   getMessaging,
@@ -20,7 +25,7 @@ export async function saveTokenToFirebase(token: string, platform: string) {
   if (!currentUser) return;
 
   try {
-    await fcmTokenRef(currentUser.uid).update({
+    await update(fcmTokenRef(currentUser.uid), {
       token,
       platform,
       updatedAt: new Date().toISOString(),
@@ -32,7 +37,7 @@ export async function saveTokenToFirebase(token: string, platform: string) {
 
 export async function removeTokenFromFirebase(uid: string) {
   try {
-    await fcmTokenRef(uid).remove();
+    await remove(fcmTokenRef(uid));
   } catch (error) {
     console.error("Failed to remove FCM token:", error);
   }
@@ -46,7 +51,7 @@ export async function updateFcmEligibility(eligibility: {
   if (!currentUser) return;
 
   try {
-    await fcmTokenRef(currentUser.uid).update({
+    await update(fcmTokenRef(currentUser.uid), {
       isSubscriber: eligibility.isSubscriber,
       isAdmin: eligibility.isAdmin,
       updatedAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- Migrate React Native Firebase namespaced `.update()` / `.remove()` / `user.delete()` calls to modular API
- Update Jest mocks for `update` and `deleteUser`

## Test plan
- [ ] Confirm deprecation warnings for `update` no longer appear on iOS launch
- [ ] Verify FCM token save/remove and eligibility updates still work when signed in
- [ ] Verify account deletion still works
- [ ] CI tests pass