### PR TITLE
fix: stop YouTube player loader from covering day tasks

### DIFF
--- a/components/common/youtube-player.tsx
+++ b/components/common/youtube-player.tsx
@@ -20,8 +20,8 @@ export function YoutubePlayer({ videoId }: { videoId: string }) {
   }
 
   return (
-    <Box className="flex-1">
-      {true && (
+    <Box className="min-h-[250px]">
+      {isLoading && (
         <Box className="absolute top-0 bottom-0 left-0 right-0 z-1">
           <Loader size="large" />
         </Box>


### PR DESCRIPTION
## Summary
- Day overview showed an endless loader with only intro text + YouTube visible; task accordions were pushed/covered below
- Root cause: `YoutubePlayer` always rendered its absolute loader (`true &&`) inside a `flex-1` box that expanded in the scroll view
- Gate the loader on `isLoading`, drop `flex-1`, and keep a 250px min height for the player area

## Test plan
- [ ] Open a day with a video + tasks
- [ ] Confirm loader disappears after the video is ready
- [ ] Confirm day/mood task accordions are visible without scrolling past a full-screen loader


Made with [Cursor](https://cursor.com)