### PR TITLE
feat: add fullscreen expand to auto-growing textarea

### DIFF
--- a/components/common/auto-growing-textarea.tsx
+++ b/components/common/auto-growing-textarea.tsx
@@ -3,22 +3,37 @@ import {
   forwardRef,
   useState,
   useCallback,
-  useEffect,
+  useRef,
+  useContext,
 } from "react";
 import {
   StyleSheet,
   StyleProp,
   TextStyle,
+  ViewStyle,
   TextInput,
   TextInputProps,
-  NativeSyntheticEvent,
-  TextInputContentSizeChangeEventData,
+  View,
+  Pressable,
+  Platform,
+  Modal,
+  ScrollView,
 } from "react-native";
+import { Maximize2, Minimize2 } from "lucide-react-native";
+import {
+  SafeAreaInsetsContext,
+  initialWindowMetrics,
+} from "react-native-safe-area-context";
+import { KeyboardAvoidingView } from "@/ui/keyboard-avoiding-view";
+
+const FALLBACK_INSETS = { top: 0, right: 0, bottom: 0, left: 0 };
 
 type Props = Omit<TextInputProps, "multiline" | "style"> & {
   minHeight?: number;
   maxHeight?: number;
   style?: StyleProp<TextStyle>;
+  containerStyle?: StyleProp<ViewStyle>;
+  expandable?: boolean;
 };
 
 export const AutoGrowingTextarea = memo(
@@ -26,46 +41,156 @@ export const AutoGrowingTextarea = memo(
     (
       {
         style,
+        containerStyle,
         minHeight = 100,
         maxHeight = 250,
-        onContentSizeChange,
+        expandable = true,
+        value,
+        onChangeText,
         ...rest
       },
       ref,
     ) => {
-      const [height, setHeight] = useState(minHeight);
+      const [isExpanded, setIsExpanded] = useState(false);
+      const [expandedDefaultValue, setExpandedDefaultValue] = useState("");
+      const [expandedSession, setExpandedSession] = useState(0);
+      const compactInputRef = useRef<TextInput | null>(null);
+      const insets =
+        useContext(SafeAreaInsetsContext) ??
+        initialWindowMetrics?.insets ??
+        FALLBACK_INSETS;
 
-      useEffect(() => {
-        setHeight(minHeight);
-      }, [minHeight]);
-
-      const handleContentSizeChange = useCallback(
-        (event: NativeSyntheticEvent<TextInputContentSizeChangeEventData>) => {
-          const contentHeight = event.nativeEvent.contentSize.height;
-          setHeight(
-            Math.min(maxHeight, Math.max(minHeight, contentHeight)),
-          );
-          onContentSizeChange?.(event);
+      const setCompactRef = useCallback(
+        (node: TextInput | null) => {
+          compactInputRef.current = node;
+          if (typeof ref === "function") {
+            ref(node);
+          } else if (ref) {
+            ref.current = node;
+          }
         },
-        [maxHeight, minHeight, onContentSizeChange],
+        [ref],
+      );
+
+      const closeExpanded = useCallback(() => {
+        setIsExpanded(false);
+      }, []);
+
+      const openExpanded = useCallback(() => {
+        compactInputRef.current?.blur();
+        setExpandedDefaultValue(typeof value === "string" ? value : "");
+        setExpandedSession((session) => session + 1);
+        setIsExpanded(true);
+      }, [value]);
+
+      const handleExpandedChange = useCallback(
+        (text: string) => {
+          onChangeText?.(text);
+        },
+        [onChangeText],
       );
 
       return (
-        <TextInput
-          ref={ref}
-          multiline
-          style={[styles.textarea, { height, minHeight }, style]}
-          onContentSizeChange={handleContentSizeChange}
-          underlineColorAndroid="transparent"
-          textAlignVertical="top"
-          {...rest}
-        />
+        <View style={[styles.container, containerStyle]}>
+          <View style={styles.compactWrapper}>
+            <TextInput
+              {...rest}
+              ref={setCompactRef}
+              value={value}
+              onChangeText={onChangeText}
+              multiline
+              editable={!isExpanded}
+              style={[
+                styles.textarea,
+                expandable && styles.textareaWithIcon,
+                { minHeight, maxHeight },
+                style,
+              ]}
+              underlineColorAndroid="transparent"
+              textAlignVertical="top"
+            />
+            {expandable ? (
+              <Pressable
+                onPress={openExpanded}
+                style={styles.expandButton}
+                hitSlop={8}
+                accessibilityRole="button"
+                accessibilityLabel="Expand textarea"
+              >
+                <Maximize2 size={18} color="#737373" />
+              </Pressable>
+            ) : null}
+          </View>
+
+          {expandable ? (
+            <Modal
+              visible={isExpanded}
+              animationType="fade"
+              presentationStyle="fullScreen"
+              onRequestClose={closeExpanded}
+            >
+              <View
+                style={[
+                  styles.expandedSafeArea,
+                  {
+                    paddingTop: insets.top,
+                    paddingBottom: insets.bottom,
+                    paddingLeft: insets.left,
+                    paddingRight: insets.right,
+                  },
+                ]}
+              >
+                <KeyboardAvoidingView
+                  style={styles.expandedRoot}
+                  behavior={Platform.OS === "ios" ? "padding" : undefined}
+                >
+                  <View style={styles.expandedHeader}>
+                    <Pressable
+                      onPress={closeExpanded}
+                      style={styles.collapseButton}
+                      hitSlop={8}
+                      accessibilityRole="button"
+                      accessibilityLabel="Collapse textarea"
+                    >
+                      <Minimize2 size={20} color="#737373" />
+                    </Pressable>
+                  </View>
+                  <ScrollView
+                    style={styles.expandedScroll}
+                    keyboardShouldPersistTaps="handled"
+                    keyboardDismissMode="interactive"
+                  >
+                    <TextInput
+                      {...rest}
+                      key={expandedSession}
+                      autoFocus
+                      multiline
+                      scrollEnabled={false}
+                      defaultValue={expandedDefaultValue}
+                      onChangeText={handleExpandedChange}
+                      style={styles.expandedTextarea}
+                      underlineColorAndroid="transparent"
+                      textAlignVertical="top"
+                    />
+                  </ScrollView>
+                </KeyboardAvoidingView>
+              </View>
+            </Modal>
+          ) : null}
+        </View>
       );
     },
   ),
 );
 
 const styles = StyleSheet.create({
+  container: {
+    width: "100%",
+  },
+  compactWrapper: {
+    position: "relative",
+    width: "100%",
+  },
   textarea: {
     width: "100%",
     borderRadius: 4,
@@ -76,6 +201,45 @@ const styles = StyleSheet.create({
     fontSize: 16,
     lineHeight: 22,
     backgroundColor: "#FFFFFF",
+  },
+  textareaWithIcon: {
+    paddingRight: 40,
+  },
+  expandButton: {
+    position: "absolute",
+    top: 8,
+    right: 8,
+    padding: 4,
+  },
+  expandedSafeArea: {
+    flex: 1,
+    backgroundColor: "#FFFFFF",
+  },
+  expandedRoot: {
+    flex: 1,
+  },
+  expandedHeader: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    alignItems: "center",
+    paddingHorizontal: 12,
+    paddingTop: 4,
+    paddingBottom: 8,
+  },
+  collapseButton: {
+    padding: 8,
+  },
+  expandedScroll: {
+    flex: 1,
+  },
+  expandedTextarea: {
+    width: "100%",
+    minHeight: 240,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    fontSize: 16,
+    lineHeight: 22,
+    color: "#000000",
   },
 });
 

--- a/components/day-tasks/goals/goals-form.tsx
+++ b/components/day-tasks/goals/goals-form.tsx
@@ -38,19 +38,24 @@ export const GoalsForm = memo(
           onSubmitEditing={handleSubmit}
         />
         <HStack space="sm" className="mt-2">
-          <Button variant="outline" onPress={onCancel} className="flex-1 rounded-lg">
+          <Button
+            variant="outline"
+            onPress={onCancel}
+            className="flex-1 rounded-lg"
+          >
             <ButtonText>{t("common.cancel")}</ButtonText>
           </Button>
           <Button
             onPress={handleSubmit}
             accessibilityLabel="Save goals"
-            className="flex-1 rounded-lg">
+            className="flex-1 rounded-lg"
+          >
             <ButtonText>{submitButtonText}</ButtonText>
           </Button>
         </HStack>
       </VStack>
     );
-  }
+  },
 );
 
 GoalsForm.displayName = "GoalsForm";

--- a/components/day-tasks/month-photo/month-photo-form.tsx
+++ b/components/day-tasks/month-photo/month-photo-form.tsx
@@ -1,8 +1,6 @@
 import { HStack } from "@/ui/hstack";
 import { VStack } from "@/ui/vstack";
-import { Text } from "@/ui/text";
 import { Button, ButtonText } from "@/ui/button";
-import { Box } from "@/ui/box";
 import { useTranslation } from "react-i18next";
 import { memo } from "react";
 import { AutoGrowingTextarea, ImagePicker } from "../../common";
@@ -45,11 +43,15 @@ export const MonthPhotoForm = memo(
           placeholder={t("screens.tasksOfTheDay.textareaPlaceholder")}
           value={text}
           onChangeText={onTextChange}
-          style={{ marginTop: 16 }}
+          containerStyle={{ marginTop: 16 }}
         />
         <HStack space="sm" className="mt-2">
           {text || image ? (
-            <Button variant="outline" onPress={onCancel} className="flex-1 rounded-lg">
+            <Button
+              variant="outline"
+              onPress={onCancel}
+              className="flex-1 rounded-lg"
+            >
               <ButtonText>{t("common.cancel")}</ButtonText>
             </Button>
           ) : null}

--- a/components/day-tasks/mood/mood-form.tsx
+++ b/components/day-tasks/mood/mood-form.tsx
@@ -1,6 +1,5 @@
 import { VStack } from "@/ui/vstack";
 import { Button, ButtonText } from "@/ui/button";
-import { Box } from "@/ui/box";
 import { useTranslation } from "react-i18next";
 import { memo } from "react";
 import { TaskOutputType } from "@/constants";
@@ -47,7 +46,7 @@ export const MoodForm = memo(
             value={text}
             onChangeText={onTextChange}
             placeholder={t("screens.tasksOfTheDay.textareaPlaceholder")}
-            style={{ marginBottom: 16 }}
+            containerStyle={{ marginBottom: 16 }}
           />
         )}
         {showImage && (

--- a/components/day-tasks/plans/add-plan-modal.tsx
+++ b/components/day-tasks/plans/add-plan-modal.tsx
@@ -1,5 +1,5 @@
 import { FormControlErrorText } from "@/ui/form-control";
-import { Textarea, TextareaInput } from "@/ui/textarea";
+import { AutoGrowingTextarea } from "@/components/common";
 
 import {
   Select,
@@ -97,14 +97,12 @@ export function AddPlanModal({
         </ModalHeader>
         <ModalBody>
           <VStack space="md">
-            <Textarea size="md" className="w-full">
-              <TextareaInput
-                onChangeText={setText}
-                defaultValue={text}
-                placeholder={t("screens.plansModal.placeholder")}
-                onSubmitEditing={handleSubmit}
-              />
-            </Textarea>
+            <AutoGrowingTextarea
+              value={text}
+              onChangeText={setText}
+              placeholder={t("screens.plansModal.placeholder")}
+              onSubmitEditing={handleSubmit}
+            />
             {isPlanScreen && (
               <>
                 <VStack space="xs">

--- a/components/day-tasks/summary/summary-form.tsx
+++ b/components/day-tasks/summary/summary-form.tsx
@@ -36,7 +36,11 @@ export const SummaryForm = memo(
           minHeight={120}
         />
         <HStack space="sm" className="mt-2">
-          <Button variant="outline" onPress={onCancel} className="flex-1 rounded-lg">
+          <Button
+            variant="outline"
+            onPress={onCancel}
+            className="flex-1 rounded-lg"
+          >
             <ButtonText>{t("common.cancel")}</ButtonText>
           </Button>
           <Button onPress={onSubmit} className="flex-1 rounded-lg">

--- a/screens/summary-screen/summary-editable-content.tsx
+++ b/screens/summary-screen/summary-editable-content.tsx
@@ -25,7 +25,11 @@ export const EditableContent = memo(
           placeholder={t("screens.tasksOfTheDay.textareaPlaceholder")}
         />
         <HStack space="sm" className="mt-2">
-          <Button variant="outline" onPress={onCancel} className="flex-1 rounded-lg">
+          <Button
+            variant="outline"
+            onPress={onCancel}
+            className="flex-1 rounded-lg"
+          >
             <ButtonText>{t("common.cancel")}</ButtonText>
           </Button>
           <Button onPress={onSubmit} className="flex-1 rounded-lg">


### PR DESCRIPTION
## Summary
- Add a top-right expand control on `AutoGrowingTextarea` that opens a fullscreen editor with a collapse button
- Grow the compact field with native `minHeight`/`maxHeight` bounds and keep fullscreen editing stable via an uncontrolled draft input
- Reuse the shared textarea in the add-plan modal and keep form Cancel/Submit actions outside the textarea

## Test plan
- [ ] Open goals/summary/mood/month-photo forms and confirm expand icon appears top-right
- [ ] Expand, type longer text, collapse, and confirm text is preserved
- [ ] Confirm Cancel/Submit still work after collapsing
- [ ] Open add-plan modal, expand textarea, type, and save a plan
- [ ] Verify no SafeAreaProvider crash inside the add-plan modal
- [ ] Verify compact textarea grows between min and max height without flickering


Made with [Cursor](https://cursor.com)