### PR TITLE
feat: add fullscreen album text reading and stabilize period overview loading

### DIFF
--- a/__tests__/screens/album-screen.test.tsx
+++ b/__tests__/screens/album-screen.test.tsx
@@ -112,11 +112,28 @@ describe("AlbumScreen", () => {
       renderWithProviders(<AlbumScreen />, {
         preloadedState: loggedInPreloadedState,
       });
-      const buttons = screen.getAllByRole("button");
-      fireEvent.press(buttons[0]);
-      fireEvent.press(buttons[buttons.length - 1]);
+      const navButtons = screen
+        .getAllByRole("button")
+        .filter(
+          (button) => button.props.accessibilityLabel !== "Expand text",
+        );
+      fireEvent.press(navButtons[0]);
+      fireEvent.press(navButtons[navButtons.length - 1]);
       expect(mockHandleBack).toHaveBeenCalledTimes(1);
       expect(mockHandleForward).toHaveBeenCalledTimes(1);
+    });
+
+    it("opens and closes fullscreen text for reading", () => {
+      renderWithProviders(<AlbumScreen />, {
+        preloadedState: loggedInPreloadedState,
+      });
+
+      fireEvent.press(screen.getAllByLabelText("Expand text")[0]);
+      expect(screen.getByLabelText("Collapse text")).toBeTruthy();
+      expect(screen.getAllByText("Winter memories").length).toBeGreaterThan(0);
+
+      fireEvent.press(screen.getByLabelText("Collapse text"));
+      expect(screen.queryByLabelText("Collapse text")).toBeNull();
     });
   });
 });

--- a/__tests__/screens/period-overview-screen.test.tsx
+++ b/__tests__/screens/period-overview-screen.test.tsx
@@ -12,14 +12,15 @@ jest.mock("@react-navigation/native", () =>
 
 const mockRefresh = jest.fn();
 const mockGetDayConfig = jest.fn();
+const mockUseCalendarDayManager = jest.fn(() => ({
+  refresh: mockRefresh,
+  isLoading: false,
+  getDayConfig: mockGetDayConfig,
+  isAdmin: false,
+}));
 
 jest.mock("../../hooks/useCalendarDayManager", () => ({
-  useCalendarDayManager: () => ({
-    refresh: mockRefresh,
-    isLoading: false,
-    getDayConfig: mockGetDayConfig,
-    isAdmin: false,
-  }),
+  useCalendarDayManager: () => mockUseCalendarDayManager(),
 }));
 
 jest.mock("../../hooks/useCurrentDate", () => ({
@@ -57,6 +58,12 @@ describe("PeriodOverviewScreen", () => {
   beforeEach(() => {
     resetNavigationMocks();
     mockRefresh.mockClear();
+    mockUseCalendarDayManager.mockReturnValue({
+      refresh: mockRefresh,
+      isLoading: false,
+      getDayConfig: mockGetDayConfig,
+      isAdmin: false,
+    });
     mockUseIAP.mockReturnValue({
       isSubscriber: false,
       isSubscriptionResolved: true,
@@ -106,5 +113,33 @@ describe("PeriodOverviewScreen", () => {
     });
     fireEvent.press(screen.getByText("Оформити підписку"));
     expect(mockNavigate).toHaveBeenCalledWith(SCREENS.PAYWALL);
+  });
+
+  it("does not render the calendar until requests finish", () => {
+    mockUseCalendarDayManager.mockReturnValue({
+      refresh: mockRefresh,
+      isLoading: true,
+      getDayConfig: mockGetDayConfig,
+      isAdmin: false,
+    });
+
+    renderWithProviders(<PeriodOverviewScreen />, {
+      preloadedState: loggedInPreloadedState,
+    });
+
+    expect(screen.queryByText("CalendarMock")).toBeNull();
+  });
+
+  it("does not render the calendar until subscription status is resolved", () => {
+    mockUseIAP.mockReturnValue({
+      isSubscriber: false,
+      isSubscriptionResolved: false,
+    });
+
+    renderWithProviders(<PeriodOverviewScreen />, {
+      preloadedState: loggedInPreloadedState,
+    });
+
+    expect(screen.queryByText("CalendarMock")).toBeNull();
   });
 });

--- a/components/common/global-loader.tsx
+++ b/components/common/global-loader.tsx
@@ -2,8 +2,12 @@ import { Box } from "@/ui/box";
 import { ActivityIndicator } from "react-native";
 import { useSelector } from "react-redux";
 import { RootState } from "../../store/store";
+import { useIAP } from "../../hooks/useIAP";
+import { isLoggedIn } from "../../store/authReducer";
 
 export const GlobalLoader = () => {
+  const { isSubscriptionResolved } = useIAP();
+  const isUserLoggedIn = useSelector(isLoggedIn);
   const isApiLoading = useSelector((state: RootState) => {
     const apiState = state.api;
     const authApiState = state.authApi;
@@ -52,7 +56,9 @@ export const GlobalLoader = () => {
     );
   });
 
-  if (!isApiLoading) return null;
+  if (!isApiLoading && !(isUserLoggedIn && !isSubscriptionResolved)) {
+    return null;
+  }
 
   return (
     <Box

--- a/components/common/safe-area-view.tsx
+++ b/components/common/safe-area-view.tsx
@@ -1,10 +1,13 @@
-import React from "react";
+import React, { useContext } from "react";
 import { StyleProp, ViewStyle } from "react-native";
 import {
-  useSafeAreaInsets,
+  SafeAreaInsetsContext,
+  initialWindowMetrics,
   type Edge,
 } from "react-native-safe-area-context";
 import { Box } from "@/ui/box";
+
+const FALLBACK_INSETS = { top: 0, right: 0, bottom: 0, left: 0 };
 
 type SafeAreaViewProps = React.ComponentProps<typeof Box> & {
   edges?: readonly Edge[];
@@ -17,7 +20,10 @@ export const SafeAreaView = React.forwardRef<
   { edges = ["top", "right", "bottom", "left"], style, ...props },
   ref
 ) {
-  const insets = useSafeAreaInsets();
+  const insets =
+    useContext(SafeAreaInsetsContext) ??
+    initialWindowMetrics?.insets ??
+    FALLBACK_INSETS;
 
   const safeAreaStyle: StyleProp<ViewStyle> = {
     paddingTop: edges.includes("top") ? insets.top : undefined,

--- a/hooks/useCalendarDayManager.ts
+++ b/hooks/useCalendarDayManager.ts
@@ -52,14 +52,17 @@ export const useCalendarDayManager = (updateCurrentDate?: () => void) => {
     }
   );
 
-  const { data: userProfile } = useGetUserProfileQuery(
+  const {
+    data: userProfile,
+    isLoading: isProfileLoading,
+  } = useGetUserProfileQuery(
     { uid: currentUser?.uid! },
     {
       skip: !currentUser?.uid,
     }
   );
 
-  const isLoading = isConfigLoading || isUserDataLoading;
+  const isLoading = isConfigLoading || isUserDataLoading || isProfileLoading;
   const error = configError || userDataError;
   const isAdmin = userProfile?.role === "admin" || false;
 

--- a/screens/album-screen/album-carousel-item.tsx
+++ b/screens/album-screen/album-carousel-item.tsx
@@ -1,10 +1,9 @@
 import { Image } from "@/ui/image";
-import { ScrollView } from "@/ui/scroll-view";
-import { Text } from "@/ui/text";
 import { Box } from "@/ui/box";
 import { memo } from "react";
 import { ImageStyle } from "react-native";
 import { MonthlyData } from "@/types";
+import { AlbumItemText } from "./album-item-text";
 
 interface AlbumCarouselItemProps {
   item: MonthlyData;
@@ -38,19 +37,7 @@ export const AlbumCarouselItem = memo(({ item }: AlbumCarouselItemProps) => {
           alt={`Photo for ${item.month}`}
         />
       </Box>
-      {hasText && (
-        <Box
-          className="h-[30%] bg-white overflow-hidden"
-          style={{
-            borderBottomRightRadius: 8,
-            borderBottomLeftRadius: 8,
-          }}
-        >
-          <ScrollView showsVerticalScrollIndicator={false} className="flex-1 p-[10px]">
-            <Text>{item.text}</Text>
-          </ScrollView>
-        </Box>
-      )}
+      {item.text ? <AlbumItemText text={item.text} /> : null}
     </Box>
   );
 });

--- a/screens/album-screen/album-item-text.tsx
+++ b/screens/album-screen/album-item-text.tsx
@@ -1,0 +1,69 @@
+import { ScrollView } from "@/ui/scroll-view";
+import { Text } from "@/ui/text";
+import { Box } from "@/ui/box";
+import { Pressable } from "@/ui/pressable";
+import { Modal, ModalBackdrop, ModalContent } from "@/ui/modal";
+import { SafeAreaView } from "@/components/common/safe-area-view";
+import { memo, useCallback, useState } from "react";
+import { Maximize2, Minimize2 } from "lucide-react-native";
+
+interface AlbumItemTextProps {
+  text: string;
+}
+
+export const AlbumItemText = memo(({ text }: AlbumItemTextProps) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const openExpanded = useCallback(() => {
+    setIsExpanded(true);
+  }, []);
+
+  const closeExpanded = useCallback(() => {
+    setIsExpanded(false);
+  }, []);
+
+  return (
+    <Box className="relative h-[30%] overflow-hidden rounded-b-lg bg-white">
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        className="flex-1 p-[10px] pr-10"
+      >
+        <Text>{text}</Text>
+      </ScrollView>
+      <Pressable
+        onPress={openExpanded}
+        className="absolute right-2 top-2 p-1"
+        hitSlop={8}
+        accessibilityRole="button"
+        accessibilityLabel="Expand text"
+      >
+        <Maximize2 size={18} color="#737373" />
+      </Pressable>
+      <Modal isOpen={isExpanded} onClose={closeExpanded} size="full">
+        <ModalBackdrop />
+        <ModalContent className="h-full w-full max-w-full rounded-none bg-white">
+          <SafeAreaView className="flex-1 bg-white">
+            <Box className="flex-row items-center justify-end px-3 pb-2 pt-1">
+              <Pressable
+                onPress={closeExpanded}
+                className="p-2"
+                hitSlop={8}
+                accessibilityRole="button"
+                accessibilityLabel="Collapse text"
+              >
+                <Minimize2 size={20} color="#737373" />
+              </Pressable>
+            </Box>
+            <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
+              <Text className="px-4 py-3 text-base leading-[22px] text-black">
+                {text}
+              </Text>
+            </ScrollView>
+          </SafeAreaView>
+        </ModalContent>
+      </Modal>
+    </Box>
+  );
+});
+
+AlbumItemText.displayName = "AlbumItemText";

--- a/screens/period-overview-screen/index.tsx
+++ b/screens/period-overview-screen/index.tsx
@@ -48,6 +48,10 @@ function PeriodOverviewScreen() {
     });
   }
 
+  if (isLoading || !isSubscriptionResolved) {
+    return <Box className="flex-1 bg-white" />;
+  }
+
   return (
     <Box className="flex-1">
       <ScrollView


### PR DESCRIPTION
## Summary
- Add a fullscreen expand control on album captions so longer text can be read outside the 30% panel
- Keep the period overview calendar hidden until config, user data, profile, and subscription status are ready
- Use a single global loader for that wait, and read safe-area insets from context so the album modal does not crash

## Test plan
- [ ] Open Album with a month that has text and confirm the maximize icon appears
- [ ] Expand, read longer text, collapse, and confirm the compact caption is unchanged
- [ ] Confirm months without text have no expand control
- [ ] Open Period Overview and confirm only one loader shows until the calendar appears
- [ ] Confirm the calendar does not flash lock/progress states while requests are in flight
- [ ] Pull to refresh Period Overview and confirm the calendar stays visible with the refresh spinner
- [ ] Expand album text on a device with a notch and confirm no SafeAreaProvider crash


Made with [Cursor](https://cursor.com)