### PR TITLE
feat: Add Apple subscription offer codes and season access updates

### DIFF
--- a/__tests__/components/calendar.test.tsx
+++ b/__tests__/components/calendar.test.tsx
@@ -3,11 +3,16 @@ import { screen } from "@testing-library/react-native";
 import { Calendar } from "../../components/calendar/calendar";
 import { renderWithProviders } from "../utils/render";
 
+const mockCapturedMaxDates: string[] = [];
+
 jest.mock("../../components/calendar/day-component", () => {
   const React = require("react");
   const { View } = require("react-native");
   return {
-    DayComponent: () => React.createElement(View, { testID: "calendar-day" }),
+    DayComponent: ({ maxDate }: { maxDate: string }) => {
+      mockCapturedMaxDates.push(maxDate);
+      return React.createElement(View, { testID: "calendar-day" });
+    },
   };
 });
 
@@ -15,10 +20,12 @@ jest.mock("@react-navigation/native", () =>
   require("../mocks/navigation").mockNavigationModule()
 );
 
+const mockUseIAP = jest.fn(() => ({
+  isSubscriber: false,
+}));
+
 jest.mock("../../hooks/useIAP", () => ({
-  useIAP: () => ({
-    isSubscriber: false,
-  }),
+  useIAP: () => mockUseIAP(),
 }));
 
 const defaultProps = {
@@ -31,8 +38,35 @@ const defaultProps = {
 };
 
 describe("Calendar", () => {
+  beforeEach(() => {
+    mockCapturedMaxDates.length = 0;
+    mockUseIAP.mockReturnValue({ isSubscriber: false });
+  });
+
   it("renders the calendar grid", () => {
     renderWithProviders(<Calendar {...defaultProps} />);
     expect(screen.getByTestId("advent-calendar")).toBeTruthy();
+  });
+
+  it("renders for store-active offer code subscribers", () => {
+    mockUseIAP.mockReturnValue({ isSubscriber: true });
+    renderWithProviders(<Calendar {...defaultProps} />);
+    expect(screen.getByTestId("advent-calendar")).toBeTruthy();
+  });
+
+  it("keeps the first three days unlocked for subscribers before 3 December", () => {
+    mockUseIAP.mockReturnValue({ isSubscriber: true });
+    renderWithProviders(
+      <Calendar {...defaultProps} currentDate="2025-12-01" />
+    );
+    expect(mockCapturedMaxDates[0]).toBe("2025-12-03");
+  });
+
+  it("unlocks later days for subscribers once they have arrived", () => {
+    mockUseIAP.mockReturnValue({ isSubscriber: true });
+    renderWithProviders(
+      <Calendar {...defaultProps} currentDate="2025-12-15" />
+    );
+    expect(mockCapturedMaxDates[0]).toBe("2025-12-15");
   });
 });

--- a/__tests__/components/day-component.test.tsx
+++ b/__tests__/components/day-component.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { fireEvent, screen, waitFor } from "@testing-library/react-native";
+import { DayComponent } from "../../components/calendar/day-component";
+import { renderWithProviders } from "../utils/render";
+
+jest.mock("react-native-circular-progress-indicator", () => {
+  const React = require("react");
+  const { Text } = require("react-native");
+  return {
+    __esModule: true,
+    default: ({ title }: { title?: string }) =>
+      React.createElement(Text, null, title),
+  };
+});
+
+const date = {
+  dateString: "2025-12-10",
+  day: 10,
+  month: 12,
+  year: 2025,
+  timestamp: Date.parse("2025-12-10"),
+};
+
+describe("DayComponent", () => {
+  it("sends non-subscribers to the paywall for locked days", () => {
+    const navigateToPaywall = jest.fn();
+    const onPress = jest.fn();
+    renderWithProviders(
+      <DayComponent
+        date={date}
+        state=""
+        onPress={onPress}
+        currentDate="2025-12-15"
+        progress={0}
+        isAdmin={false}
+        isSubscriber={false}
+        maxDate="2025-12-03"
+        navigateToPaywall={navigateToPaywall}
+      />
+    );
+    fireEvent.press(screen.getByTestId("calendar-day-2025-12-10"));
+    expect(navigateToPaywall).toHaveBeenCalled();
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it("unlocks calendar days for store-active offer code subscribers", async () => {
+    const navigateToPaywall = jest.fn();
+    const onPress = jest.fn();
+    renderWithProviders(
+      <DayComponent
+        date={date}
+        state=""
+        onPress={onPress}
+        currentDate="2025-12-15"
+        progress={0}
+        isAdmin={false}
+        isSubscriber={true}
+        maxDate="2025-12-15"
+        navigateToPaywall={navigateToPaywall}
+      />
+    );
+    fireEvent.press(screen.getByTestId("calendar-day-2025-12-10"));
+    await waitFor(() => {
+      expect(onPress).toHaveBeenCalledWith("2025-12-10");
+    });
+    expect(navigateToPaywall).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/year-selector.test.tsx
+++ b/__tests__/components/year-selector.test.tsx
@@ -1,11 +1,62 @@
 import React from "react";
-import { screen } from "@testing-library/react-native";
+import { fireEvent, screen, waitFor } from "@testing-library/react-native";
 import { YearSelector } from "../../components/navigation/year-selector";
 import { renderWithProviders } from "../utils/render";
+import { loggedInPreloadedState } from "../utils/day-task-helpers";
+import { selectSelectedYear } from "../../store/appReducer";
+import { YEARS } from "@/constants";
+
+const currentYear = YEARS[YEARS.length - 1];
+const previousYear = YEARS[0];
+
+const mockFetchUserYearData = jest.fn((args: { year: string }) => ({
+  unwrap: () =>
+    Promise.resolve(args.year === previousYear ? { days: {} } : null),
+}));
+
+jest.mock("../../services/api", () => ({
+  ...jest.requireActual("../../services/api"),
+  useLazyGetUserDataQuery: () => [mockFetchUserYearData],
+}));
 
 describe("YearSelector", () => {
+  beforeEach(() => {
+    mockFetchUserYearData.mockClear();
+  });
+
   it("renders the current year when no user is logged in", () => {
     renderWithProviders(<YearSelector />);
-    expect(screen.getByText("2025")).toBeTruthy();
+    expect(screen.getByTestId("year-selector-label")).toBeTruthy();
+    expect(screen.getByText(currentYear)).toBeTruthy();
+  });
+
+  it("opens a dropdown of available years next to the trigger", async () => {
+    renderWithProviders(<YearSelector />, {
+      preloadedState: loggedInPreloadedState,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("year-selector-trigger")).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByTestId("year-selector-trigger"));
+
+    expect(screen.getByText(previousYear)).toBeTruthy();
+    expect(screen.getAllByText(currentYear).length).toBeGreaterThan(0);
+  });
+
+  it("updates the selected year from the dropdown", async () => {
+    const { store } = renderWithProviders(<YearSelector />, {
+      preloadedState: loggedInPreloadedState,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("year-selector-trigger")).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByTestId("year-selector-trigger"));
+    fireEvent.press(screen.getByText(previousYear));
+
+    expect(selectSelectedYear(store.getState())).toBe(previousYear);
   });
 });

--- a/__tests__/screens/paywall-screen.test.tsx
+++ b/__tests__/screens/paywall-screen.test.tsx
@@ -1,22 +1,66 @@
 import React from "react";
-import { screen } from "@testing-library/react-native";
+import { Alert, Platform } from "react-native";
+import { fireEvent, screen, waitFor } from "@testing-library/react-native";
 import { PaywallScreen } from "../../screens/paywall-screen";
 import { renderWithProviders } from "../utils/render";
 
+const mockSubscribe = jest.fn();
+const mockRedeemOfferCode = jest.fn();
+const mockRestorePurchases = jest.fn();
+
+const mockUseIAP = jest.fn(() => ({
+  subscriptions: [{ id: "test.subscription" }],
+  isLoading: false,
+  subscribe: mockSubscribe,
+  redeemOfferCode: mockRedeemOfferCode,
+  restorePurchases: mockRestorePurchases,
+  activeProductId: null,
+  isInitialized: true,
+  priceLabel: "$12.99",
+  isSubscriber: false,
+  isStoreReady: true,
+  errorMessage: null,
+  isAwaitingOfferRedemption: false,
+}));
+
 jest.mock("../../hooks/useIAP", () => ({
-  useIAP: () => ({
-    subscriptions: [{ id: "test.subscription" }],
-    isLoading: false,
-    subscribe: jest.fn(),
-    activeProductId: null,
-    isInitialized: true,
-    priceLabel: "$12.99",
-    isSubscriber: false,
-    isStoreReady: true,
-  }),
+  useIAP: () => mockUseIAP(),
 }));
 
 describe("PaywallScreen", () => {
+  const originalOs = Platform.OS;
+
+  beforeEach(() => {
+    mockSubscribe.mockReset();
+    mockRedeemOfferCode.mockReset();
+    mockRestorePurchases.mockReset().mockResolvedValue(true);
+    mockUseIAP.mockReturnValue({
+      subscriptions: [{ id: "test.subscription" }],
+      isLoading: false,
+      subscribe: mockSubscribe,
+      redeemOfferCode: mockRedeemOfferCode,
+      restorePurchases: mockRestorePurchases,
+      activeProductId: null,
+      isInitialized: true,
+      priceLabel: "$12.99",
+      isSubscriber: false,
+      isStoreReady: true,
+      errorMessage: null,
+      isAwaitingOfferRedemption: false,
+    });
+    Object.defineProperty(Platform, "OS", {
+      configurable: true,
+      get: () => originalOs,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(Platform, "OS", {
+      configurable: true,
+      get: () => originalOs,
+    });
+  });
+
   it("renders subscribe CTA", () => {
     renderWithProviders(<PaywallScreen />);
     expect(screen.getByText("Оформити підписку")).toBeTruthy();
@@ -25,5 +69,84 @@ describe("PaywallScreen", () => {
   it("renders manage subscription link", () => {
     renderWithProviders(<PaywallScreen />);
     expect(screen.getByText("Керувати підпискою")).toBeTruthy();
+  });
+
+  it("opens the Apple offer code redemption sheet", () => {
+    Object.defineProperty(Platform, "OS", {
+      configurable: true,
+      get: () => "ios",
+    });
+    renderWithProviders(<PaywallScreen />);
+    fireEvent.press(screen.getByText("Маєте промокод?"));
+    expect(mockRedeemOfferCode).toHaveBeenCalled();
+  });
+
+  it("hides the promo code entry on Android", () => {
+    Object.defineProperty(Platform, "OS", {
+      configurable: true,
+      get: () => "android",
+    });
+    renderWithProviders(<PaywallScreen />);
+    expect(screen.queryByText("Маєте промокод?")).toBeNull();
+  });
+
+  it("hides the promo code entry for subscribers", () => {
+    Object.defineProperty(Platform, "OS", {
+      configurable: true,
+      get: () => "ios",
+    });
+    mockUseIAP.mockReturnValue({
+      subscriptions: [{ id: "test.subscription" }],
+      isLoading: false,
+      subscribe: mockSubscribe,
+      redeemOfferCode: mockRedeemOfferCode,
+      restorePurchases: mockRestorePurchases,
+      activeProductId: "test.subscription",
+      isInitialized: true,
+      priceLabel: "$12.99",
+      isSubscriber: true,
+      isStoreReady: true,
+      errorMessage: null,
+      isAwaitingOfferRedemption: false,
+    });
+    renderWithProviders(<PaywallScreen />);
+    expect(screen.queryByText("Маєте промокод?")).toBeNull();
+  });
+
+  it("shows a loader while offer redemption is finishing", () => {
+    Object.defineProperty(Platform, "OS", {
+      configurable: true,
+      get: () => "ios",
+    });
+    mockUseIAP.mockReturnValue({
+      subscriptions: [{ id: "test.subscription" }],
+      isLoading: true,
+      subscribe: mockSubscribe,
+      redeemOfferCode: mockRedeemOfferCode,
+      restorePurchases: mockRestorePurchases,
+      activeProductId: null,
+      isInitialized: true,
+      priceLabel: "$12.99",
+      isSubscriber: false,
+      isStoreReady: true,
+      errorMessage: null,
+      isAwaitingOfferRedemption: true,
+    });
+    renderWithProviders(<PaywallScreen />);
+    expect(screen.getByTestId("paywall-redeem-loader")).toBeTruthy();
+  });
+
+  it("restores purchases", async () => {
+    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+    renderWithProviders(<PaywallScreen />);
+    fireEvent.press(screen.getByText("Відновити доступ"));
+    expect(mockRestorePurchases).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        "Відновити доступ",
+        "Доступ відновлено."
+      );
+    });
+    alertSpy.mockRestore();
   });
 });

--- a/__tests__/screens/period-overview-screen.test.tsx
+++ b/__tests__/screens/period-overview-screen.test.tsx
@@ -4,7 +4,16 @@ import PeriodOverviewScreen from "../../screens/period-overview-screen";
 import { renderWithProviders } from "../utils/render";
 import { loggedInPreloadedState } from "../utils/day-task-helpers";
 import { mockNavigate, resetNavigationMocks } from "../mocks/navigation";
-import { SCREENS } from "@/constants";
+import { SCREENS, YEARS } from "@/constants";
+
+const currentYear = YEARS[YEARS.length - 1];
+const currentSeasonState = {
+  ...loggedInPreloadedState,
+  app: {
+    ...loggedInPreloadedState.app!,
+    selectedYear: currentYear,
+  },
+};
 
 jest.mock("@react-navigation/native", () =>
   require("../mocks/navigation").mockNavigationModule()
@@ -72,14 +81,14 @@ describe("PeriodOverviewScreen", () => {
 
   it("renders the calendar", () => {
     renderWithProviders(<PeriodOverviewScreen />, {
-      preloadedState: loggedInPreloadedState,
+      preloadedState: currentSeasonState,
     });
     expect(screen.getByText("CalendarMock")).toBeTruthy();
   });
 
   it("navigates to the day overview when a calendar day is pressed", () => {
     renderWithProviders(<PeriodOverviewScreen />, {
-      preloadedState: loggedInPreloadedState,
+      preloadedState: currentSeasonState,
     });
     fireEvent.press(screen.getByTestId("calendar-press"));
     expect(mockNavigate).toHaveBeenCalledWith("DayOverview", {
@@ -89,10 +98,23 @@ describe("PeriodOverviewScreen", () => {
 
   it("shows the paywall banner for non-subscribers on the current year", () => {
     renderWithProviders(<PeriodOverviewScreen />, {
-      preloadedState: loggedInPreloadedState,
+      preloadedState: currentSeasonState,
     });
     expect(screen.getByText("Відкрий усі дні з Jingle Plan+")).toBeTruthy();
     expect(screen.getByText("Оформити підписку")).toBeTruthy();
+  });
+
+  it("hides the paywall banner on a previous year", () => {
+    renderWithProviders(<PeriodOverviewScreen />, {
+      preloadedState: {
+        ...loggedInPreloadedState,
+        app: {
+          ...loggedInPreloadedState.app!,
+          selectedYear: YEARS[0],
+        },
+      },
+    });
+    expect(screen.queryByText("Відкрий усі дні з Jingle Plan+")).toBeNull();
   });
 
   it("hides the paywall banner for subscribers", () => {
@@ -102,14 +124,14 @@ describe("PeriodOverviewScreen", () => {
     });
 
     renderWithProviders(<PeriodOverviewScreen />, {
-      preloadedState: loggedInPreloadedState,
+      preloadedState: currentSeasonState,
     });
     expect(screen.queryByText("Відкрий усі дні з Jingle Plan+")).toBeNull();
   });
 
   it("navigates to the paywall screen from the banner", () => {
     renderWithProviders(<PeriodOverviewScreen />, {
-      preloadedState: loggedInPreloadedState,
+      preloadedState: currentSeasonState,
     });
     fireEvent.press(screen.getByText("Оформити підписку"));
     expect(mockNavigate).toHaveBeenCalledWith(SCREENS.PAYWALL);
@@ -124,7 +146,7 @@ describe("PeriodOverviewScreen", () => {
     });
 
     renderWithProviders(<PeriodOverviewScreen />, {
-      preloadedState: loggedInPreloadedState,
+      preloadedState: currentSeasonState,
     });
 
     expect(screen.queryByText("CalendarMock")).toBeNull();
@@ -137,7 +159,7 @@ describe("PeriodOverviewScreen", () => {
     });
 
     renderWithProviders(<PeriodOverviewScreen />, {
-      preloadedState: loggedInPreloadedState,
+      preloadedState: currentSeasonState,
     });
 
     expect(screen.queryByText("CalendarMock")).toBeNull();

--- a/__tests__/screens/register-screen.test.tsx
+++ b/__tests__/screens/register-screen.test.tsx
@@ -96,6 +96,19 @@ describe("RegisterScreen", () => {
       ).toBeTruthy();
     });
 
+    it("accepts a password that includes a special character", () => {
+      renderWithProviders(<RegisterScreen />);
+      fireEvent.changeText(
+        screen.getByPlaceholderText(PASSWORD_PLACEHOLDER),
+        "Password1!"
+      );
+      expect(
+        screen.queryByText(
+          "Пароль має складатись із щонайменше 8 символів і містити хоча б одну цифру та хоча б одну велику літеру"
+        )
+      ).toBeNull();
+    });
+
     it("shows a mismatch error when passwords differ", () => {
       renderWithProviders(<RegisterScreen />);
       fireEvent.changeText(
@@ -107,6 +120,19 @@ describe("RegisterScreen", () => {
         "Password2"
       );
       expect(screen.getByText("Паролі не збігаються")).toBeTruthy();
+    });
+
+    it("clears the mismatch error when the password is filled after the repeat field", () => {
+      renderWithProviders(<RegisterScreen />);
+      fireEvent.changeText(
+        screen.getByPlaceholderText(REPEAT_PLACEHOLDER),
+        "Password1"
+      );
+      fireEvent.changeText(
+        screen.getByPlaceholderText(PASSWORD_PLACEHOLDER),
+        "Password1"
+      );
+      expect(screen.queryByText("Паролі не збігаються")).toBeNull();
     });
 
     it("shows a name error when name is blurred empty", () => {

--- a/components/calendar/calendar.tsx
+++ b/components/calendar/calendar.tsx
@@ -9,12 +9,12 @@ import { calendarTheme, setupCalendarLocale } from "../../utils/calendar-utils";
 import { DayComponent } from "./day-component";
 import { useIAP } from "../../hooks/useIAP";
 import { useNavigation } from "@react-navigation/native";
-import { SCREENS, YEARS } from "@/constants";
+import { SCREENS } from "@/constants";
 
 interface CalendarProps {
   pressHandler: (dateString: string) => void;
   getDayConfig: ReturnType<
-    typeof import("../../hooks/useCalendarDayManager")["useCalendarDayManager"]
+    (typeof import("../../hooks/useCalendarDayManager"))["useCalendarDayManager"]
   >["getDayConfig"];
   isAdmin: boolean;
   isLoading: boolean;
@@ -34,30 +34,28 @@ export const Calendar = memo(
     const selectedYear = useAppSelector(selectSelectedYear);
     const navigation = useNavigation();
     const { isSubscriber } = useIAP();
-    // const { i18n } = useTranslation();
-    // const resolvedLanguage =
-    //   (i18n.resolvedLanguage as keyof typeof LANGUAGES) || "en";
-
     const locale = "uk";
+    // const currentDate = "2026-12-01";
 
     setupCalendarLocale(locale);
 
     const minDate = useMemo(
       () => moment(`${selectedYear}-12-01`).format("YYYY-MM-DD"),
-      [selectedYear]
+      [selectedYear],
     );
 
     const firstUnlockedDate = useMemo(
       () => moment(`${currentYear}-12-03`).format("YYYY-MM-DD"),
-      [currentYear]
+      [currentYear],
     );
 
     const baseMaxDate = useMemo(() => {
       const today = moment(currentDate, "YYYY-MM-DD");
       const thirdDay = moment(firstUnlockedDate, "YYYY-MM-DD");
-      return isSubscriber
-        ? today.format("YYYY-MM-DD")
-        : thirdDay.format("YYYY-MM-DD");
+      if (!isSubscriber) {
+        return thirdDay.format("YYYY-MM-DD");
+      }
+      return moment.max(today, thirdDay).format("YYYY-MM-DD");
     }, [currentDate, firstUnlockedDate, isSubscriber]);
 
     const maxDate = useMemo(
@@ -65,7 +63,7 @@ export const Calendar = memo(
         isAdmin
           ? moment(`${selectedYear}-12-31`).format("YYYY-MM-DD")
           : baseMaxDate,
-      [isAdmin, baseMaxDate, selectedYear]
+      [isAdmin, baseMaxDate, selectedYear],
     );
 
     const renderDayComponent = useCallback(
@@ -101,7 +99,7 @@ export const Calendar = memo(
         maxDate,
         isAdmin,
         isLoading,
-      ]
+      ],
     );
 
     return (
@@ -120,7 +118,7 @@ export const Calendar = memo(
         />
       </Box>
     );
-  }
+  },
 );
 
 Calendar.displayName = "Calendar";

--- a/components/calendar/day-component.tsx
+++ b/components/calendar/day-component.tsx
@@ -89,7 +89,7 @@ export const DayComponent = memo(
     const tooltipMessage = unlockMessage ?? defaultLockedMessage;
 
     return (
-      <Pressable onPress={handlePress}>
+      <Pressable testID={`calendar-day-${date.dateString}`} onPress={handlePress}>
         {({ pressed }) => (
           <Box className="items-center justify-center">
             {disabled ? (

--- a/components/navigation/year-selector.tsx
+++ b/components/navigation/year-selector.tsx
@@ -1,22 +1,15 @@
-import {
-  Select,
-  SelectTrigger,
-  SelectPortal,
-  SelectBackdrop,
-  SelectContent,
-  SelectDragIndicator,
-  SelectDragIndicatorWrapper,
-  SelectItem,
-} from "@/ui/select";
-
 import { Text } from "@/ui/text";
 import { Box } from "@/ui/box";
-import { useEffect, useState } from "react";
+import { Menu, MenuItem } from "@/ui/menu";
+import { Pressable } from "@/ui/pressable";
+import { useEffect, useMemo, useState } from "react";
 import { useAppDispatch, useAppSelector } from "../../store/withTypes";
 import { setSelectedYear, selectSelectedYear } from "../../store/appReducer";
 import { YEARS } from "@/constants";
+import { colors } from "@/constants/colors";
 import { useLazyGetUserDataQuery } from "../../services/api";
-import { ChevronDown } from "lucide-react-native";
+import { Check, ChevronDown } from "lucide-react-native";
+import * as Haptics from "expo-haptics";
 
 export const YearSelector = () => {
   const dispatch = useAppDispatch();
@@ -43,9 +36,7 @@ export const YearSelector = () => {
           if (data) {
             yearsWithData.add(year);
           }
-        } catch (error) {
-          // ignore errors per year; we'll keep existing list
-        }
+        } catch {}
       }
 
       if (!isActive) return;
@@ -64,7 +55,18 @@ export const YearSelector = () => {
     };
   }, [userUid, fetchUserYearData, currentYear]);
 
+  const yearsNewestFirst = useMemo(
+    () => [...availableYears].sort((a, b) => Number(b) - Number(a)),
+    [availableYears],
+  );
+
   const handleYearChange = (value: string) => {
+    if (value === selectedYear) {
+      return;
+    }
+    try {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    } catch {}
     dispatch(setSelectedYear(value));
   };
 
@@ -73,46 +75,70 @@ export const YearSelector = () => {
   return (
     <Box className="pl-[16px]">
       {singleYear ? (
-        <Box className="bg-white px-3 py-2 min-w-[60px] items-center">
+        <Box
+          testID="year-selector-label"
+          className="bg-white px-3 py-2 min-h-[44px] min-w-[72px] items-center justify-center"
+        >
           <Text className="text-lg font-semibold text-warmGray-800">
             {singleYear}
           </Text>
         </Box>
       ) : (
-        <Select
-          key={selectedYear}
-          selectedValue={selectedYear}
-          onValueChange={handleYearChange}
+        <Menu
+          placement="bottom left"
+          offset={6}
+          style={{ width: 148, borderRadius: 12, paddingVertical: 6 }}
+          trigger={(triggerProps, state) => {
+            const isOpen = Boolean(state?.open);
+            return (
+              <Pressable
+                {...triggerProps}
+                testID="year-selector-trigger"
+                accessibilityRole="button"
+                accessibilityLabel={selectedYear}
+                hitSlop={8}
+              >
+                <Box className="bg-white px-3 py-2 min-h-[44px] min-w-[72px] items-center flex-row gap-1">
+                  <Text className="text-lg font-semibold text-warmGray-800">
+                    {selectedYear}
+                  </Text>
+                  <ChevronDown
+                    size={18}
+                    color={colors.warmGray400}
+                    style={{
+                      transform: [{ rotate: isOpen ? "180deg" : "0deg" }],
+                    }}
+                  />
+                </Box>
+              </Pressable>
+            );
+          }}
         >
-          <SelectTrigger className="border-[0px]">
-            <Box className="bg-white px-3 py-2 min-w-[60px] items-center flex-row gap-1">
-              <Text className="text-lg font-semibold text-warmGray-800">
-                {selectedYear}
-              </Text>
-              <ChevronDown size={16} color="#999999" />
-            </Box>
-          </SelectTrigger>
-          <SelectPortal>
-            <SelectBackdrop />
-            <SelectContent className="pb-10">
-              <SelectDragIndicatorWrapper>
-                <SelectDragIndicator />
-              </SelectDragIndicatorWrapper>
-              {availableYears.length ? (
-                availableYears.map((year) => (
-                  <SelectItem key={year} label={year} value={year} />
-                ))
-              ) : (
-                <SelectItem
-                  isDisabled
-                  key="no-data"
-                  label={selectedYear}
-                  value={selectedYear}
-                />
-              )}
-            </SelectContent>
-          </SelectPortal>
-        </Select>
+          {yearsNewestFirst.map((year) => {
+            const isSelected = year === selectedYear;
+            return (
+              <MenuItem
+                key={year}
+                textValue={year}
+                onPress={() => handleYearChange(year)}
+                className="px-4 min-h-[48px] justify-between active:bg-coolGray-100"
+              >
+                <Text
+                  className={`text-base ${
+                    isSelected
+                      ? "font-semibold text-warmGray-800"
+                      : "text-warmGray-800"
+                  }`}
+                >
+                  {year}
+                </Text>
+                {isSelected ? (
+                  <Check size={18} color={colors.primary500} strokeWidth={2.5} />
+                ) : null}
+              </MenuItem>
+            );
+          })}
+        </Menu>
       )}
     </Box>
   );

--- a/constants/months.ts
+++ b/constants/months.ts
@@ -1,4 +1,4 @@
-export const YEARS = ["2024", "2025"] as const;
+export const YEARS = ["2024", "2025", "2026"] as const;
 
 export const OPEN_DAYS_FROM_TODAY = 0;
 

--- a/constants/validation.ts
+++ b/constants/validation.ts
@@ -1,2 +1,2 @@
 export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-export const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/;
+export const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)\S{8,}$/;

--- a/i18n/global-resources/en.ts
+++ b/i18n/global-resources/en.ts
@@ -189,6 +189,10 @@ export default {
     lockedCalendarDescription:
       "Only subscribers can open all calendar days and view daily reflections as soon as they’re available.",
     goToStore: "Upgrade now",
+    promoCta: "Have a promo code?",
+    restore: "Restore purchases",
+    restoreSuccess: "Your purchases were restored.",
+    restoreEmpty: "No purchases were found to restore.",
   },
   rating: {
     bad: "Bad",

--- a/i18n/global-resources/ua.ts
+++ b/i18n/global-resources/ua.ts
@@ -53,6 +53,10 @@ export default {
     lockedCalendarDescription:
       "Лише підписники отримують доступ до всіх завдань календаря.",
     goToStore: "Оформити підписку",
+    promoCta: "Маєте промокод?",
+    restore: "Відновити доступ",
+    restoreSuccess: "Доступ відновлено.",
+    restoreEmpty: "Доступу для відновлення не знайдено.",
   },
   context: {
     health: "Тіло",

--- a/providers/IAPProvider.tsx
+++ b/providers/IAPProvider.tsx
@@ -1,12 +1,20 @@
 import React, {
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
+import { AppState, AppStateStatus, Platform } from "react-native";
 import { useTranslation } from "react-i18next";
-import { useIAP as useExpoIAP, type Product, ErrorCode } from "expo-iap";
+import {
+  useIAP as useExpoIAP,
+  type Product,
+  ErrorCode,
+  presentCodeRedemptionSheetIOS,
+} from "expo-iap";
 import type { IapContextValue } from "../types/iap";
 import { SUBSCRIPTION_IDS } from "../config/iap";
 import { AppEventsLogger } from "react-native-fbsdk-next";
@@ -34,46 +42,58 @@ export function IAPProvider({ children }: { children: React.ReactNode }) {
     SUBSCRIPTION_IDS.length === 0
   );
   const [isStoreReady, setIsStoreReady] = useState(false);
+  const catalogRef = useRef<Product[]>([]);
+  const awaitingOfferRef = useRef(false);
+  const [isAwaitingOfferRedemption, setIsAwaitingOfferRedemption] =
+    useState(false);
+
+  const stopAwaitingOffer = useCallback(() => {
+    awaitingOfferRef.current = false;
+    setIsAwaitingOfferRedemption(false);
+  }, []);
 
   const {
     connected,
     products,
+    subscriptions: storeSubscriptions,
     fetchProducts,
     requestPurchase,
     finishTransaction,
     hasActiveSubscriptions,
+    restorePurchases: restorePurchasesFromStore,
   } = useExpoIAP({
     onPurchaseSuccess: async (purchase) => {
       try {
         await finishTransaction({ purchase, isConsumable: false });
         setActiveProductId(purchase.productId ?? null);
         setHasActiveSubscription(true);
+        stopAwaitingOffer();
 
         try {
-          if (products && Array.isArray(products)) {
-            const product = products.find((p) => p.id === purchase.productId);
-            if (product) {
-              const price =
-                typeof product.price === "number"
-                  ? product.price
-                  : typeof product.price === "string"
-                  ? parseFloat(product.price)
-                  : 0;
-              const currency = product.currency || "USD";
+          const product = catalogRef.current.find(
+            (item) => item.id === purchase.productId
+          );
+          if (product) {
+            const price =
+              typeof product.price === "number"
+                ? product.price
+                : typeof product.price === "string"
+                ? parseFloat(product.price)
+                : 0;
+            const currency = product.currency || "USD";
 
-              if (price > 0) {
-                try {
-                  AppEventsLogger.logPurchase(price, currency);
-                  AppEventsLogger.logEvent("Subscribe", {
-                    value: price,
-                    currency: currency,
-                  });
-                } catch (fbError) {
-                  console.log(
-                    "Failed to log Facebook purchase event:",
-                    fbError
-                  );
-                }
+            if (price > 0) {
+              try {
+                AppEventsLogger.logPurchase(price, currency);
+                AppEventsLogger.logEvent("Subscribe", {
+                  value: price,
+                  currency: currency,
+                });
+              } catch (fbError) {
+                console.log(
+                  "Failed to log Facebook purchase event:",
+                  fbError
+                );
               }
             }
           }
@@ -81,6 +101,7 @@ export function IAPProvider({ children }: { children: React.ReactNode }) {
           console.log("Error logging Facebook events:", fbError);
         }
       } catch (error) {
+        stopAwaitingOffer();
         setErrorMessage(
           error instanceof Error
             ? error.message
@@ -89,6 +110,7 @@ export function IAPProvider({ children }: { children: React.ReactNode }) {
       }
     },
     onPurchaseError: (error) => {
+      stopAwaitingOffer();
       if (error?.code === ErrorCode.UserCancelled) return;
       setErrorMessage(
         error?.message ?? t("errors.generic", "Something went wrong")
@@ -96,18 +118,22 @@ export function IAPProvider({ children }: { children: React.ReactNode }) {
     },
   });
 
-  const subscriptions = useMemo<Product[]>(
-    () => sortByPrice(products),
-    [products]
-  );
+  const subscriptions = useMemo<Product[]>(() => {
+    const catalog =
+      storeSubscriptions.length > 0 ? storeSubscriptions : products;
+    return sortByPrice(catalog as Product[]);
+  }, [storeSubscriptions, products]);
+  catalogRef.current = subscriptions;
   const priceLabel = subscriptions[0]?.displayPrice ?? null;
   const defaultProductId = subscriptions[0]?.id ?? SUBSCRIPTION_IDS[0] ?? null;
   const isInitialized = connected;
   const isLoading =
-    isPurchasing || isFetchingProducts || isCheckingSubscription;
+    isPurchasing ||
+    isFetchingProducts ||
+    isCheckingSubscription ||
+    isAwaitingOfferRedemption;
   const isSubscriber = hasActiveSubscription || activeProductId != null;
 
-  // Debounce readiness 1 tick after connected to avoid races
   useEffect(() => {
     if (!connected) {
       setIsStoreReady(false);
@@ -117,7 +143,6 @@ export function IAPProvider({ children }: { children: React.ReactNode }) {
     return () => clearTimeout(timer);
   }, [connected]);
 
-  // Fetch product catalog
   useEffect(() => {
     if (!isStoreReady || !SUBSCRIPTION_IDS.length) return;
     setIsFetchingProducts(true);
@@ -136,66 +161,114 @@ export function IAPProvider({ children }: { children: React.ReactNode }) {
     })();
   }, [isStoreReady, fetchProducts, t]);
 
-  // Check entitlements with retry and unfiltered fallback
+  const refreshEntitlements = useCallback(async (silent = false): Promise<boolean> => {
+    if (!isStoreReady || !SUBSCRIPTION_IDS.length) {
+      return false;
+    }
+    if (!silent) {
+      setIsCheckingSubscription(true);
+    }
+    try {
+      let hasActive = await hasActiveSubscriptions(SUBSCRIPTION_IDS);
+      if (!hasActive) {
+        hasActive = await hasActiveSubscriptions();
+      }
+      if (!hasActive) {
+        await new Promise((r) => setTimeout(r, 500));
+        hasActive =
+          (await hasActiveSubscriptions(SUBSCRIPTION_IDS)) ||
+          (await hasActiveSubscriptions());
+      }
+      setHasActiveSubscription(hasActive);
+      if (hasActive) {
+        setActiveProductId((cur) => cur ?? defaultProductId ?? null);
+        stopAwaitingOffer();
+      } else {
+        setActiveProductId(null);
+      }
+      return hasActive;
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : t("errors.generic", "Something went wrong")
+      );
+      return false;
+    } finally {
+      if (!silent) {
+        setIsCheckingSubscription(false);
+      }
+      setIsSubscriptionResolved(true);
+    }
+  }, [isStoreReady, hasActiveSubscriptions, defaultProductId, stopAwaitingOffer, t]);
+
   useEffect(() => {
     if (!isStoreReady || !SUBSCRIPTION_IDS.length) return;
-    let mounted = true;
-    (async () => {
-      setIsCheckingSubscription(true);
+    void refreshEntitlements();
+  }, [isStoreReady, refreshEntitlements]);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener(
+      "change",
+      (nextAppState: AppStateStatus) => {
+        if (nextAppState === "active") {
+          void refreshEntitlements();
+        }
+      }
+    );
+    return () => subscription.remove();
+  }, [refreshEntitlements]);
+
+  const subscribe = useCallback(
+    async (productId: string) => {
       try {
-        // 1) Filtered by known SKU
-        let hasActive = await hasActiveSubscriptions(SUBSCRIPTION_IDS);
-        // 2) Unfiltered as safety net
-        if (!hasActive) {
-          hasActive = await hasActiveSubscriptions();
+        if (!isInitialized || !isStoreReady) {
+          setErrorMessage(t("errors.generic", "Something went wrong"));
+          return;
         }
-        // 3) Retry once after short delay to handle post-init lag
-        if (!hasActive) {
-          await new Promise((r) => setTimeout(r, 500));
-          hasActive =
-            (await hasActiveSubscriptions(SUBSCRIPTION_IDS)) ||
-            (await hasActiveSubscriptions());
-        }
-        if (!mounted) return;
-        setHasActiveSubscription(hasActive);
-        if (hasActive) {
-          setActiveProductId((cur) => cur ?? defaultProductId ?? null);
-        } else {
-          setActiveProductId(null);
-        }
+        setErrorMessage(null);
+        setIsPurchasing(true);
+        await requestPurchase({
+          request: {
+            ios: { sku: productId },
+            android: { skus: [productId] },
+          },
+          type: "subs",
+        });
       } catch (error) {
-        if (!mounted) return;
         setErrorMessage(
           error instanceof Error
             ? error.message
             : t("errors.generic", "Something went wrong")
         );
       } finally {
-        if (mounted) {
-          setIsCheckingSubscription(false);
-          setIsSubscriptionResolved(true);
-        }
+        setIsPurchasing(false);
       }
-    })();
-    return () => {
-      mounted = false;
-    };
-  }, [isStoreReady, hasActiveSubscriptions, defaultProductId, t]);
+    },
+    [isInitialized, isStoreReady, requestPurchase, t]
+  );
 
-  const subscribe = async (productId: string) => {
+  const redeemOfferCode = useCallback(async () => {
     try {
+      if (Platform.OS !== "ios") {
+        return;
+      }
       if (!isInitialized || !isStoreReady) {
         setErrorMessage(t("errors.generic", "Something went wrong"));
         return;
       }
-      setIsPurchasing(true);
-      await requestPurchase({
-        request: {
-          ios: { sku: productId },
-          android: { skus: [productId] },
-        },
-        type: "subs",
-      });
+      setErrorMessage(null);
+      awaitingOfferRef.current = true;
+      setIsAwaitingOfferRedemption(true);
+      await presentCodeRedemptionSheetIOS();
+      const deadline = Date.now() + 12000;
+      while (awaitingOfferRef.current && Date.now() < deadline) {
+        const hasActive = await refreshEntitlements(true);
+        if (hasActive) {
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 400));
+      }
     } catch (error) {
       setErrorMessage(
         error instanceof Error
@@ -203,9 +276,37 @@ export function IAPProvider({ children }: { children: React.ReactNode }) {
           : t("errors.generic", "Something went wrong")
       );
     } finally {
+      stopAwaitingOffer();
+    }
+  }, [isInitialized, isStoreReady, refreshEntitlements, stopAwaitingOffer, t]);
+
+  const restorePurchases = useCallback(async () => {
+    try {
+      if (!isInitialized || !isStoreReady) {
+        setErrorMessage(t("errors.generic", "Something went wrong"));
+        return false;
+      }
+      setErrorMessage(null);
+      setIsPurchasing(true);
+      await restorePurchasesFromStore();
+      return await refreshEntitlements();
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : t("errors.generic", "Something went wrong")
+      );
+      return false;
+    } finally {
       setIsPurchasing(false);
     }
-  };
+  }, [
+    isInitialized,
+    isStoreReady,
+    refreshEntitlements,
+    restorePurchasesFromStore,
+    t,
+  ]);
 
   const value: IapContextValue = {
     isInitialized,
@@ -216,8 +317,11 @@ export function IAPProvider({ children }: { children: React.ReactNode }) {
     isSubscriber,
     activeProductId,
     isLoading,
+    isAwaitingOfferRedemption,
     errorMessage,
     subscribe,
+    redeemOfferCode,
+    restorePurchases,
   };
   return <IapContext.Provider value={value}>{children}</IapContext.Provider>;
 }

--- a/screens/intro-screen/index.tsx
+++ b/screens/intro-screen/index.tsx
@@ -139,7 +139,7 @@ export function IntroScreen() {
               } catch {}
               nav.replace(SCREENS.REGISTER);
             }}
-            className="mt-2"
+            className="mt-5"
           >
             <ButtonText>{t("screens.intro.loginBtn")}</ButtonText>
           </Button>
@@ -151,7 +151,7 @@ export function IntroScreen() {
               nav.replace(SCREENS.LOGIN);
             }}
             variant="outline"
-            className="mt-2"
+            className="mt-3"
           >
             <ButtonText>{t("screens.intro.signupBtn")}</ButtonText>
           </Button>

--- a/screens/login-screen/index.tsx
+++ b/screens/login-screen/index.tsx
@@ -8,11 +8,12 @@ import { Box } from "@/ui/box";
 import { useNavigation } from "@react-navigation/native";
 import { useEffect, useState, useCallback } from "react";
 import { SafeAreaView } from "../../components/common/safe-area-view";
-import { Alert, Keyboard, Switch } from "react-native";
+import { Alert, Keyboard, Platform, Switch } from "react-native";
 import { SCREENS, EMAIL_REGEX } from "@/constants";
 import { useTranslation } from "react-i18next";
 import { EyeIcon, EyeOffIcon } from "lucide-react-native";
-import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
+import { KeyboardAvoidingView } from "@/ui/keyboard-avoiding-view";
+import { ScrollView } from "@/ui/scroll-view";
 import {
   useSignInUserMutation,
   useSendPasswordResetMutation,
@@ -153,12 +154,16 @@ export const LoginScreen = () => {
 
   return (
     <Pressable onPress={Keyboard.dismiss} className="flex-1">
-      <KeyboardAwareScrollView
-        enableResetScrollToCoords={false}
-        keyboardShouldPersistTaps="handled"
-        enableOnAndroid={true}
-        enableAutomaticScroll={true}
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
       >
+        <ScrollView
+          style={{ flex: 1 }}
+          contentContainerStyle={{ flexGrow: 1 }}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="on-drag"
+        >
         <SafeAreaView className="flex-1">
           <Box className="flex-col p-[10px] pt-[30px] justify-center">
             <Box className="pb-[10px]">
@@ -200,6 +205,10 @@ export const LoginScreen = () => {
                     onChangeText={setPassword}
                     type={showPassword ? "text" : "password"}
                     placeholder={t("screens.loginScreen.passwordPlaceholder")}
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    textContentType="password"
+                    autoComplete="password"
                   />
                   <InputSlot onPress={handleState} className="pr-3">
                     <InputIcon
@@ -238,7 +247,8 @@ export const LoginScreen = () => {
             </Button>
           </Box>
         </SafeAreaView>
-      </KeyboardAwareScrollView>
+        </ScrollView>
+      </KeyboardAvoidingView>
     </Pressable>
   );
 };

--- a/screens/paywall-screen/index.tsx
+++ b/screens/paywall-screen/index.tsx
@@ -13,6 +13,9 @@ import {
   EXPO_PUBLIC_ANDROID_SUBSCRIPTION_ID,
 } from "@env";
 import { Alert, Linking, Platform } from "react-native";
+import { Pressable } from "@/ui/pressable";
+import { Loader } from "@/components/common";
+import { PromoCodeSection } from "./promo-code-section";
 
 const MANAGE_SUBSCRIPTION_URL_IOS =
   "https://apps.apple.com/account/subscriptions";
@@ -30,6 +33,9 @@ export const PaywallScreen = memo(() => {
     priceLabel,
     isSubscriber,
     isStoreReady,
+    errorMessage,
+    restorePurchases,
+    isAwaitingOfferRedemption,
   } = useIAP();
   const fallbackProductId =
     Platform.OS === "android"
@@ -59,6 +65,18 @@ export const PaywallScreen = memo(() => {
       Alert.alert(t("common.error"), t("errors.generic"));
     }
   }, [t]);
+
+  const handleRestorePurchases = useCallback(async () => {
+    try {
+      const restored = await restorePurchases();
+      Alert.alert(
+        t("paywall.restore"),
+        restored ? t("paywall.restoreSuccess") : t("paywall.restoreEmpty")
+      );
+    } catch {
+      Alert.alert(t("common.error"), t("errors.generic"));
+    }
+  }, [restorePurchases, t]);
 
   return (
     <Box className="flex-1 bg-white">
@@ -120,15 +138,34 @@ export const PaywallScreen = memo(() => {
                 {isLoading ? t("paywall.processing") : subscribeButtonLabel}
               </ButtonText>
             </Button>
+            <PromoCodeSection />
           </Box>
 
-          <Button variant="link" onPress={handleManageSubscription}>
-            <ButtonText className="text-primary-600">
-              {t("common.manageSubscription")}
-            </ButtonText>
-          </Button>
+          {errorMessage ? (
+            <Text className="text-sm text-red-500 text-center">
+              {errorMessage}
+            </Text>
+          ) : null}
 
-          <Text className="text-xs text-warmGray-500">
+          <HStack space="md" className="justify-center items-center">
+            <Pressable
+              onPress={handleRestorePurchases}
+              disabled={isLoading || !isInitialized || !isStoreReady}
+              className="py-2"
+            >
+              <Text className="text-sm text-warmGray-500">
+                {t("paywall.restore")}
+              </Text>
+            </Pressable>
+            <Text className="text-sm text-warmGray-300">·</Text>
+            <Pressable onPress={handleManageSubscription} className="py-2">
+              <Text className="text-sm text-warmGray-500">
+                {t("common.manageSubscription")}
+              </Text>
+            </Pressable>
+          </HStack>
+
+          <Text className="text-xs text-warmGray-400 text-center">
             {t(
               Platform.OS === "android"
                 ? "paywall.disclaimerAndroid"
@@ -137,6 +174,14 @@ export const PaywallScreen = memo(() => {
           </Text>
         </VStack>
       </ScrollView>
+      {isAwaitingOfferRedemption ? (
+        <Box
+          testID="paywall-redeem-loader"
+          className="absolute left-0 right-0 top-0 bottom-0 z-10"
+        >
+          <Loader absolute />
+        </Box>
+      ) : null}
     </Box>
   );
 });

--- a/screens/paywall-screen/promo-code-section.tsx
+++ b/screens/paywall-screen/promo-code-section.tsx
@@ -1,0 +1,34 @@
+import { memo, useCallback } from "react";
+import { Platform } from "react-native";
+import { useTranslation } from "react-i18next";
+import { Button, ButtonText } from "@/ui/button";
+import { useIAP } from "@/hooks/useIAP";
+
+export const PromoCodeSection = memo(() => {
+  const { t } = useTranslation();
+  const { isLoading, isInitialized, isStoreReady, isSubscriber, redeemOfferCode } =
+    useIAP();
+
+  const handleRedeem = useCallback(() => {
+    void redeemOfferCode();
+  }, [redeemOfferCode]);
+
+  if (Platform.OS !== "ios" || isSubscriber) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="outline"
+      isDisabled={isLoading || !isInitialized || !isStoreReady}
+      onPress={handleRedeem}
+      className="mt-3 rounded-xl border-primary-600"
+    >
+      <ButtonText className="text-primary-600">
+        {t("paywall.promoCta")}
+      </ButtonText>
+    </Button>
+  );
+});
+
+PromoCodeSection.displayName = "PromoCodeSection";

--- a/screens/period-overview-screen/index.tsx
+++ b/screens/period-overview-screen/index.tsx
@@ -6,7 +6,7 @@ import { useCallback, useState } from "react";
 import { RefreshControl } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
-import { HomeStackParamList } from "./home-screen";
+import { HomeStackParamList } from "@/screens/home-screen";
 import { Calendar } from "../../components/calendar/calendar";
 import { useCalendarDayManager } from "../../hooks/useCalendarDayManager";
 import { useIAP } from "../../hooks/useIAP";

--- a/screens/register-screen/index.tsx
+++ b/screens/register-screen/index.tsx
@@ -6,14 +6,15 @@ import { Heading } from "@/ui/heading";
 import { ButtonText, Button } from "@/ui/button";
 import { Box } from "@/ui/box";
 import { useNavigation } from "@react-navigation/native";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { SafeAreaView } from "../../components/common/safe-area-view";
-import { Alert, Keyboard } from "react-native";
+import { Alert, Keyboard, Platform } from "react-native";
 import * as Haptics from "expo-haptics";
 import { SCREENS, EMAIL_REGEX, PASSWORD_REGEX } from "@/constants";
 import { useTranslation } from "react-i18next";
 import { EyeIcon, EyeOffIcon } from "lucide-react-native";
-import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
+import { KeyboardAvoidingView } from "@/ui/keyboard-avoiding-view";
+import { ScrollView } from "@/ui/scroll-view";
 import { useAppDispatch } from "../../store/withTypes";
 import { setUser, setAuthError, setAuthLoading } from "../../store/authReducer";
 import { useCreateUserMutation } from "../../services/auth-api-rtk";
@@ -39,6 +40,8 @@ export const RegisterScreen = () => {
   const [passwordError, setPasswordError] = useState("");
   const [passwordMatchError, setPasswordMatchError] = useState("");
   const [nameError, setNameError] = useState("");
+  const passwordValueRef = useRef("");
+  const repeatPasswordValueRef = useRef("");
 
   const dispatch = useAppDispatch();
   const [createUser] = useCreateUserMutation();
@@ -78,87 +81,104 @@ export const RegisterScreen = () => {
     }
   };
 
+  const validatePasswordMatch = (nextPassword: string, nextRepeat: string) => {
+    if (!nextPassword || !nextRepeat) {
+      setPasswordMatchError("");
+      return;
+    }
+    setPasswordMatchError(
+      nextPassword !== nextRepeat
+        ? t("screens.registerScreen.passwordMatchError")
+        : "",
+    );
+  };
+
   const handleRegister = async () => {
     const trimmedName = name.trim();
     const trimmedEmail = email.trim();
+    const currentPassword = passwordValueRef.current || password;
+    const currentRepeat = repeatPasswordValueRef.current || repeatPassword;
+    validateEmail(trimmedEmail);
+    validatePassword(currentPassword);
+    validateName(trimmedName);
+    validatePasswordMatch(currentPassword, currentRepeat);
     if (
-      !emailError &&
-      !passwordError &&
-      !passwordMatchError &&
-      !nameError &&
-      trimmedEmail &&
-      password &&
-      repeatPassword &&
-      trimmedName
+      !trimmedEmail ||
+      !EMAIL_REGEX.test(trimmedEmail) ||
+      !PASSWORD_REGEX.test(currentPassword) ||
+      currentPassword !== currentRepeat ||
+      !trimmedName
     ) {
+      return;
+    }
+    try {
       try {
-        try {
-          await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-        } catch {}
-        dispatch(setAuthLoading());
-        const user = await createUser({
-          email: trimmedEmail,
-          password,
-        }).unwrap();
-        const serializableUser = convertToSerializableUser(user, trimmedName);
+        await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+      } catch {}
+      dispatch(setAuthLoading());
+      const user = await createUser({
+        email: trimmedEmail,
+        password: currentPassword,
+      }).unwrap();
+      const serializableUser = convertToSerializableUser(user, trimmedName);
 
-        await createProfile({
-          uid: user.uid,
-          name: trimmedName,
-          email: user.email || trimmedEmail,
-        }).unwrap();
+      await createProfile({
+        uid: user.uid,
+        name: trimmedName,
+        email: user.email || trimmedEmail,
+      }).unwrap();
 
-        const shouldRemember = await new Promise<boolean>((resolve) => {
-          Alert.alert(
-            t("screens.registerScreen.savePasswordTitle"),
-            t("screens.registerScreen.savePasswordMessage"),
-            [
-              {
-                text: t("common.cancel"),
-                style: "cancel",
-                onPress: () => {
-                  clearCredentials().finally(() => resolve(false));
-                },
+      const shouldRemember = await new Promise<boolean>((resolve) => {
+        Alert.alert(
+          t("screens.registerScreen.savePasswordTitle"),
+          t("screens.registerScreen.savePasswordMessage"),
+          [
+            {
+              text: t("common.cancel"),
+              style: "cancel",
+              onPress: () => {
+                clearCredentials().finally(() => resolve(false));
               },
-              {
-                text: t("screens.registerScreen.savePasswordConfirm"),
-                onPress: () => {
-                  saveCredentials(trimmedEmail, password)
-                    .then(() => resolve(true))
-                    .catch(() => resolve(false));
-                },
+            },
+            {
+              text: t("screens.registerScreen.savePasswordConfirm"),
+              onPress: () => {
+                saveCredentials(trimmedEmail, currentPassword)
+                  .then(() => resolve(true))
+                  .catch(() => resolve(false));
               },
-            ],
-          );
-        });
+            },
+          ],
+        );
+      });
 
-        if (!shouldRemember) {
-          await clearCredentials();
-        }
-
-        dispatch(setUser(serializableUser));
-        nav.replace(SCREENS.HOME);
-      } catch (error) {
-        const message =
-          resolveErrorMessage(error) ??
-          t("errors.generic", "An error occurred");
-
-        dispatch(setAuthError(message));
-        Alert.alert(t("common.error"), message);
+      if (!shouldRemember) {
+        await clearCredentials();
       }
+
+      dispatch(setUser(serializableUser));
+      nav.replace(SCREENS.HOME);
+    } catch (error) {
+      const message =
+        resolveErrorMessage(error) ??
+        t("errors.generic", "An error occurred");
+
+      dispatch(setAuthError(message));
+      Alert.alert(t("common.error"), message);
     }
   };
 
   const handlePasswordChange = (value: string) => {
+    passwordValueRef.current = value;
     setPassword(value);
     validatePassword(value);
+    validatePasswordMatch(value, repeatPasswordValueRef.current);
   };
 
   const handleRepeatPasswordChange = (value: string) => {
+    repeatPasswordValueRef.current = value;
     setRepeatPassword(value);
-    setPasswordMatchError(
-      value !== password ? t("screens.registerScreen.passwordMatchError") : "",
-    );
+    validatePasswordMatch(passwordValueRef.current, value);
   };
 
   const handleNameChange = (value: string) => {
@@ -168,13 +188,17 @@ export const RegisterScreen = () => {
 
   return (
     <Pressable onPress={Keyboard.dismiss} className="flex-1">
-      <KeyboardAwareScrollView
-        enableResetScrollToCoords={false}
-        keyboardShouldPersistTaps="handled"
-        enableOnAndroid={true}
-        enableAutomaticScroll={true}
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
       >
-        <SafeAreaView className="flex-1">
+        <ScrollView
+          style={{ flex: 1 }}
+          contentContainerStyle={{ flexGrow: 1 }}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="on-drag"
+        >
+          <SafeAreaView className="flex-1">
           <Box className="p-[10px]">
             <Box className="pb-[10px]">
               <Heading>{t("screens.registerScreen.title")}</Heading>
@@ -241,6 +265,10 @@ export const RegisterScreen = () => {
                     type={showPassword ? "text" : "password"}
                     onChangeText={handlePasswordChange}
                     placeholder={t("screens.registerScreen.password")}
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    textContentType="newPassword"
+                    autoComplete="new-password"
                   />
                   <InputSlot onPress={handleState} className="pr-3">
                     <InputIcon
@@ -263,6 +291,10 @@ export const RegisterScreen = () => {
                     type={showPassword ? "text" : "password"}
                     onChangeText={handleRepeatPasswordChange}
                     placeholder={t("screens.registerScreen.repeatPassword")}
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    textContentType="newPassword"
+                    autoComplete="new-password"
                   />
                 </Input>
                 {passwordMatchError ? (
@@ -283,8 +315,9 @@ export const RegisterScreen = () => {
               <ButtonText>{t("screens.registerScreen.registerBtn")}</ButtonText>
             </Button>
           </Box>
-        </SafeAreaView>
-      </KeyboardAwareScrollView>
+          </SafeAreaView>
+        </ScrollView>
+      </KeyboardAvoidingView>
     </Pressable>
   );
 };

--- a/types/iap.ts
+++ b/types/iap.ts
@@ -11,12 +11,12 @@ export interface IapContextValue {
   isSubscriptionResolved: boolean;
   isSubscriber: boolean;
   activeProductId: string | null;
-  // inflight
   isLoading: boolean;
-  // error
+  isAwaitingOfferRedemption: boolean;
   errorMessage: string | null;
-  // actions
   subscribe: (productId: string) => Promise<void>;
+  redeemOfferCode: () => Promise<void>;
+  restorePurchases: () => Promise<boolean>;
 }
 
 


### PR DESCRIPTION
## Summary
- Wire iOS paywall to Apple Subscription Offer Codes (`presentCodeRedemptionSheetIOS`), restore access, and refresh entitlements when the app returns to the foreground.
- Keep 1–3 December unlocked for every user (including subscribers); add 2026 to the season list; replace the year bottom sheet with a header dropdown.
- Allow special characters in passwords, fix register autofill mismatch, and swap `KeyboardAwareScrollView` on login/register to stop the iOS “Error measuring text field” warning.

## Test plan
- [ ] On a real iPhone with a Sandbox Apple ID, open the paywall and redeem a **Sandbox** subscription offer code (production codes do not work in sandbox). Confirm the loader, then that the calendar unlocks.
- [ ] Restore access from the paywall footer; confirm manage subscription still opens Apple’s subscription page.
- [ ] Confirm Android paywall has no promo CTA.
- [ ] As a subscriber with today set to 1 Dec, days 1–3 are open; later days stay locked until they arrive.
- [ ] Switch years from the header dropdown (not a bottom sheet) when a previous season has data.
- [ ] Register with a password that includes a special character; use iOS suggested password and confirm both fields match.
- [ ] Confirm login/register no longer log “Error measuring text field” during password autofill.

Made with [Cursor](https://cursor.com)